### PR TITLE
Constants externals

### DIFF
--- a/charon/src/common.rs
+++ b/charon/src/common.rs
@@ -11,6 +11,25 @@ use std::iter::FromIterator;
 /// Our redefinition of Result - we don't care much about the I/O part.
 pub type Result<T> = std::result::Result<T, ()>;
 
+/// Propagate the error from a callback to the caller :
+/// Used to avoid saving, checking and returning the result by hand.
+/// The callback will not be called again if it returned an error.
+/// The dynamic signature is used to pass a generic function as argument.
+/// A simple use case is shown in [test_propagate_error].
+pub fn propagate_error<T, C, F>(consumer: C, mut callback: F) -> Result<()>
+where
+    F: FnMut(T) -> Result<()>,
+    C: FnOnce(&mut dyn FnMut(T) -> ()),
+{
+    let mut res = Ok(());
+    consumer(&mut |arg: T| {
+        if res.is_ok() {
+            res = callback(arg);
+        }
+    });
+    res
+}
+
 /// We use both `ErrorEmitter` and the logger to report errors and warnings.
 /// Those two ways of reporting information don't target the same usage and
 /// the same users.
@@ -316,4 +335,22 @@ impl<'a, K: Serialize, V: Serialize> Serialize for LinkedHashMapSerializer<'a, K
     {
         serialize_collection(self.map.iter(), serializer)
     }
+}
+
+#[test]
+fn test_propagate_error() {
+    let ints = &[1, 2, 3, 4, 5, 6];
+    let mut sum = 0;
+    let res = propagate_error(
+        |f| ints.iter().for_each(f),
+        |x| {
+            if x == &4 {
+                return Err(());
+            }
+            sum += x;
+            Ok(())
+        },
+    );
+    assert!(res.is_err());
+    assert!(sum == 6);
 }

--- a/charon/src/common.rs
+++ b/charon/src/common.rs
@@ -26,11 +26,11 @@ pub trait ErrorEmitter {
 
 impl ErrorEmitter for Session {
     fn span_err<S: Into<MultiSpan>>(&self, s: S, msg: &str) {
-        self.span_err_with_code(s, msg, DiagnosticId::Error(String::from("Aenea")));
+        self.span_err_with_code(s, msg, DiagnosticId::Error(String::from("Aeneas")));
     }
 
     fn span_warn<S: Into<MultiSpan>>(&self, s: S, msg: &str) {
-        self.span_warn_with_code(s, msg, DiagnosticId::Error(String::from("Aenea")));
+        self.span_warn_with_code(s, msg, DiagnosticId::Error(String::from("Aeneas")));
     }
 }
 

--- a/charon/src/divergent.rs
+++ b/charon/src/divergent.rs
@@ -84,8 +84,8 @@ pub fn compute_divergent_functions(
                     divergent_map.insert(*id, true);
                 }
             }
-            DeclarationGroup::Type(_) | DeclarationGroup::Const(_) => {
-                // Ignore the type & constant declarations
+            DeclarationGroup::Type(_) | DeclarationGroup::Global(_) => {
+                // Ignore the type & global declarations
                 continue;
             }
         }

--- a/charon/src/expressions.rs
+++ b/charon/src/expressions.rs
@@ -1,7 +1,7 @@
 //! Implements expressions: paths, operands, rvalues, lvalues
 
 pub use crate::expressions_utils::*;
-use crate::im_ast::ConstDeclId;
+use crate::im_ast::GlobalDeclId;
 use crate::types::*;
 use crate::values::*;
 use im::Vector;
@@ -115,8 +115,8 @@ pub enum BinOp {
 pub enum Operand {
     Copy(Place),
     Move(Place),
-    /// Constant value.
-    Constant(ETy, OperandConstantValue),
+    /// Constant global value.
+    Const(ETy, OperandConstantValue),
 }
 
 /// Constant value for an operand.
@@ -146,7 +146,7 @@ pub enum OperandConstantValue {
     /// The case when the constant is elsewhere.
     /// The MIR seems to forbid more complex expressions like paths :
     /// Reading the constant a.b is translated to { _1 = const a; _2 = (_1.0) }.
-    Identifier(ConstDeclId::Id),
+    Identifier(GlobalDeclId::Id),
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/charon/src/expressions_utils.rs
+++ b/charon/src/expressions_utils.rs
@@ -5,7 +5,7 @@ use crate::assumed;
 use crate::common::*;
 use crate::expressions::*;
 use crate::formatter::Formatter;
-use crate::im_ast::ConstDeclId;
+use crate::im_ast::GlobalDeclId;
 use crate::types::*;
 use crate::values;
 use crate::values::*;
@@ -121,7 +121,7 @@ impl std::string::ToString for Place {
 impl OperandConstantValue {
     pub fn fmt_with_ctx<T>(&self, ctx: &T) -> String
     where
-        T: Formatter<TypeDeclId::Id> + Formatter<ConstDeclId::Id>,
+        T: Formatter<TypeDeclId::Id> + Formatter<GlobalDeclId::Id>,
     {
         match self {
             OperandConstantValue::ConstantValue(c) => c.to_string(),
@@ -152,13 +152,13 @@ impl Operand {
     where
         T: Formatter<VarId::Id>
             + Formatter<TypeDeclId::Id>
-            + Formatter<ConstDeclId::Id>
+            + Formatter<GlobalDeclId::Id>
             + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>,
     {
         match self {
             Operand::Copy(p) => format!("copy ({})", p.fmt_with_ctx(ctx)).to_string(),
             Operand::Move(p) => format!("move ({})", p.fmt_with_ctx(ctx)).to_string(),
-            Operand::Constant(_, c) => format!("const ({})", c.fmt_with_ctx(ctx)).to_string(),
+            Operand::Const(_, c) => format!("const ({})", c.fmt_with_ctx(ctx)).to_string(),
         }
     }
 
@@ -179,7 +179,7 @@ impl Rvalue {
     where
         T: Formatter<VarId::Id>
             + Formatter<TypeDeclId::Id>
-            + Formatter<ConstDeclId::Id>
+            + Formatter<GlobalDeclId::Id>
             + Formatter<(TypeDeclId::Id, VariantId::Id)>
             + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>,
     {

--- a/charon/src/generics.rs
+++ b/charon/src/generics.rs
@@ -130,7 +130,7 @@ pub(crate) fn check_type_generics<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) {
     check_generics(tcx, def_id)
 }
 
-/// Check a constant's generics (to refuse them except Sized trait)
+/// Check a global's generics (to refuse them except Sized trait)
 pub(crate) fn check_global_generics<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) {
     assert!(tcx.generics_of(def_id).params.is_empty());
     check_generics(tcx, def_id)

--- a/charon/src/generics.rs
+++ b/charon/src/generics.rs
@@ -131,7 +131,7 @@ pub(crate) fn check_type_generics<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) {
 }
 
 /// Check a constant's generics (to refuse them except Sized trait)
-pub(crate) fn check_constant_generics<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) {
+pub(crate) fn check_global_generics<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) {
     assert!(tcx.generics_of(def_id).params.is_empty());
     check_generics(tcx, def_id)
 }

--- a/charon/src/im_ast.rs
+++ b/charon/src/im_ast.rs
@@ -66,13 +66,17 @@ pub struct FunSig {
     pub output: RTy,
 }
 
-/// A function body
+/// An expression body.
+/// TODO: arg_count should be stored in GFunDecl below. But then,
+///       the print is obfuscated and Aeneas needs to be adjusted.
 #[derive(Debug, Clone, Serialize)]
-pub struct GFunBody<T: std::fmt::Debug + Clone + Serialize> {
+pub struct GExprBody<T: std::fmt::Debug + Clone + Serialize> {
     pub arg_count: usize,
     pub locals: VarId::Vector<Var>,
     pub body: T,
 }
+
+pub type ExprBody = GExprBody<BlockId::Vector<BlockData>>;
 
 /// A function definition
 #[derive(Debug, Clone, Serialize)]
@@ -85,26 +89,19 @@ pub struct GFunDecl<T: std::fmt::Debug + Clone + Serialize> {
     /// The function body, in case the function is not opaque.
     /// Opaque functions are: external functions, or local functions tagged
     /// as opaque.
-    pub body: Option<GFunBody<T>>,
+    pub body: Option<GExprBody<T>>,
 }
 
-pub type FunBody = GFunBody<BlockId::Vector<BlockData>>;
 pub type FunDecl = GFunDecl<BlockId::Vector<BlockData>>;
 pub type FunDecls = FunDeclId::Vector<FunDecl>;
 
-#[derive(Debug, Clone, Serialize)]
-pub struct GGlobalBody<T: std::fmt::Debug + Clone + Serialize> {
-    pub locals: VarId::Vector<Var>,
-    pub body: T,
-}
-
-/// A constant definition, either opaque or transparent.
+/// A global variable definition, either opaque or transparent.
 #[derive(Debug, Clone, Serialize)]
 pub struct GGlobalDecl<T: std::fmt::Debug + Clone + Serialize> {
     pub def_id: GlobalDeclId::Id,
     pub name: GlobalName,
     pub type_: ETy,
-    pub body: Option<GGlobalBody<T>>,
+    pub body: Option<GExprBody<T>>,
 }
 impl<T: std::fmt::Debug + Clone + Serialize> GGlobalDecl<T> {
     fn is_opaque(&self) -> bool {
@@ -112,7 +109,6 @@ impl<T: std::fmt::Debug + Clone + Serialize> GGlobalDecl<T> {
     }
 }
 
-pub type GlobalBody = GGlobalBody<BlockId::Vector<BlockData>>;
 pub type GlobalDecl = GGlobalDecl<BlockId::Vector<BlockData>>;
 pub type GlobalDecls = GlobalDeclId::Vector<GlobalDecl>;
 

--- a/charon/src/im_ast.rs
+++ b/charon/src/im_ast.rs
@@ -5,8 +5,8 @@
 
 use crate::expressions::*;
 pub use crate::im_ast_utils::*;
-use crate::names::ConstName;
 use crate::names::FunName;
+use crate::names::GlobalName;
 use crate::regions_hierarchy::RegionGroups;
 use crate::types::*;
 use crate::values::*;
@@ -19,7 +19,7 @@ use serde::Serialize;
 pub static TAB_INCR: &'static str = "    ";
 
 generate_index_type!(FunDeclId);
-generate_index_type!(ConstDeclId);
+generate_index_type!(GlobalDeclId);
 
 // Block identifier. Similar to rust's `BasicBlock`.
 generate_index_type!(BlockId);
@@ -93,28 +93,28 @@ pub type FunDecl = GFunDecl<BlockId::Vector<BlockData>>;
 pub type FunDecls = FunDeclId::Vector<FunDecl>;
 
 #[derive(Debug, Clone, Serialize)]
-pub struct GConstBody<T: std::fmt::Debug + Clone + Serialize> {
+pub struct GGlobalBody<T: std::fmt::Debug + Clone + Serialize> {
     pub locals: VarId::Vector<Var>,
     pub body: T,
 }
 
 /// A constant definition, either opaque or transparent.
 #[derive(Debug, Clone, Serialize)]
-pub struct GConstDecl<T: std::fmt::Debug + Clone + Serialize> {
-    pub def_id: ConstDeclId::Id,
-    pub name: ConstName,
+pub struct GGlobalDecl<T: std::fmt::Debug + Clone + Serialize> {
+    pub def_id: GlobalDeclId::Id,
+    pub name: GlobalName,
     pub type_: ETy,
-    pub body: Option<GConstBody<T>>,
+    pub body: Option<GGlobalBody<T>>,
 }
-impl<T: std::fmt::Debug + Clone + Serialize> GConstDecl<T> {
+impl<T: std::fmt::Debug + Clone + Serialize> GGlobalDecl<T> {
     fn is_opaque(&self) -> bool {
         self.body.is_none()
     }
 }
 
-pub type ConstBody = GConstBody<BlockId::Vector<BlockData>>;
-pub type ConstDecl = GConstDecl<BlockId::Vector<BlockData>>;
-pub type ConstDecls = ConstDeclId::Vector<ConstDecl>;
+pub type GlobalBody = GGlobalBody<BlockId::Vector<BlockData>>;
+pub type GlobalDecl = GGlobalDecl<BlockId::Vector<BlockData>>;
+pub type GlobalDecls = GlobalDeclId::Vector<GlobalDecl>;
 
 #[derive(Debug, Clone, EnumIsA, EnumAsGetters, VariantName, Serialize)]
 pub enum Statement {

--- a/charon/src/im_ast_utils.rs
+++ b/charon/src/im_ast_utils.rs
@@ -173,7 +173,7 @@ impl Statement {
     where
         T: Formatter<VarId::Id>
             + Formatter<TypeDeclId::Id>
-            + Formatter<ConstDeclId::Id>
+            + Formatter<GlobalDeclId::Id>
             + Formatter<(TypeDeclId::Id, VariantId::Id)>
             + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>,
     {
@@ -225,7 +225,7 @@ where
         + Formatter<&'a ErasedRegion>
         + Formatter<TypeDeclId::Id>
         + Formatter<FunDeclId::Id>
-        + Formatter<ConstDeclId::Id>
+        + Formatter<GlobalDeclId::Id>
         + Formatter<(TypeDeclId::Id, VariantId::Id)>
         + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>,
 {
@@ -283,7 +283,7 @@ impl Terminator {
             + Formatter<&'a ErasedRegion>
             + Formatter<TypeDeclId::Id>
             + Formatter<FunDeclId::Id>
-            + Formatter<ConstDeclId::Id>
+            + Formatter<GlobalDeclId::Id>
             + Formatter<(TypeDeclId::Id, VariantId::Id)>
             + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>,
     {
@@ -360,7 +360,7 @@ impl BlockData {
             + Formatter<&'a ErasedRegion>
             + Formatter<TypeDeclId::Id>
             + Formatter<FunDeclId::Id>
-            + Formatter<ConstDeclId::Id>
+            + Formatter<GlobalDeclId::Id>
             + Formatter<(TypeDeclId::Id, VariantId::Id)>
             + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>,
     {
@@ -390,7 +390,7 @@ where
         + Formatter<&'a ErasedRegion>
         + Formatter<TypeDeclId::Id>
         + Formatter<FunDeclId::Id>
-        + Formatter<ConstDeclId::Id>
+        + Formatter<GlobalDeclId::Id>
         + Formatter<(TypeDeclId::Id, VariantId::Id)>
         + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>,
 {
@@ -427,7 +427,7 @@ impl<T: std::fmt::Debug + Clone + Serialize> GFunBody<T> {
             + Formatter<&'a ErasedRegion>
             + Formatter<TypeDeclId::Id>
             + Formatter<FunDeclId::Id>
-            + Formatter<ConstDeclId::Id>
+            + Formatter<GlobalDeclId::Id>
             + Formatter<(TypeDeclId::Id, VariantId::Id)>
             + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>
             + Formatter<&'a T>,
@@ -482,7 +482,7 @@ impl<T: std::fmt::Debug + Clone + Serialize> GFunBody<T> {
 }
 
 // TODO: As usual, we need to refactor functions & constants together.
-impl<T: std::fmt::Debug + Clone + Serialize> GConstBody<T> {
+impl<T: std::fmt::Debug + Clone + Serialize> GGlobalBody<T> {
     /// This is an auxiliary function for printing definitions. One may wonder
     /// why we require a formatter to format, for instance, (type) var ids,
     /// because the constant definition already has the information to print
@@ -497,7 +497,7 @@ impl<T: std::fmt::Debug + Clone + Serialize> GConstBody<T> {
             + Formatter<&'a ErasedRegion>
             + Formatter<TypeDeclId::Id>
             + Formatter<FunDeclId::Id>
-            + Formatter<ConstDeclId::Id>
+            + Formatter<GlobalDeclId::Id>
             + Formatter<(TypeDeclId::Id, VariantId::Id)>
             + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>
             + Formatter<&'a T>,
@@ -660,7 +660,7 @@ impl<T: std::fmt::Debug + Clone + Serialize> GFunDecl<T> {
             + Formatter<TypeDeclId::Id>
             + Formatter<&'a ErasedRegion>
             + Formatter<FunDeclId::Id>
-            + Formatter<ConstDeclId::Id>
+            + Formatter<GlobalDeclId::Id>
             + Formatter<(TypeDeclId::Id, VariantId::Id)>
             + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>
             + Formatter<&'a T>,
@@ -737,7 +737,7 @@ impl<T: std::fmt::Debug + Clone + Serialize> GFunDecl<T> {
 }
 
 // TODO: Refactor with functions.
-impl<CD: std::fmt::Debug + Clone + Serialize> GConstDecl<CD> {
+impl<CD: std::fmt::Debug + Clone + Serialize> GGlobalDecl<CD> {
     /// This is an auxiliary function for printing definitions. One may wonder
     /// why we require a formatter to format, for instance, (type) var ids,
     /// because the constant definition already has the information to print
@@ -752,7 +752,7 @@ impl<CD: std::fmt::Debug + Clone + Serialize> GConstDecl<CD> {
             + Formatter<TypeDeclId::Id>
             + Formatter<&'a ErasedRegion>
             + Formatter<FunDeclId::Id>
-            + Formatter<ConstDeclId::Id>
+            + Formatter<GlobalDeclId::Id>
             + Formatter<(TypeDeclId::Id, VariantId::Id)>
             + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>
             + Formatter<&'a CD>,
@@ -764,7 +764,7 @@ impl<CD: std::fmt::Debug + Clone + Serialize> GConstDecl<CD> {
         match &self.body {
             Option::None => {
                 // Put everything together
-                format!("{}const {}", tab, name).to_owned()
+                format!("{}global {}", tab, name).to_owned()
             }
             Option::Some(body) => {
                 // Body
@@ -772,7 +772,7 @@ impl<CD: std::fmt::Debug + Clone + Serialize> GConstDecl<CD> {
                 let body = body.fmt_with_ctx(&body_tab, body_ctx);
 
                 // Put everything together
-                format!("{}const {} {{\n{}\n{}}}", tab, name, body, tab).to_owned()
+                format!("{}global {} {{\n{}\n{}}}", tab, name, body, tab).to_owned()
             }
         }
     }
@@ -781,12 +781,12 @@ impl<CD: std::fmt::Debug + Clone + Serialize> GConstDecl<CD> {
 pub struct GAstFormatter<'ctx, FD, CD> {
     pub type_context: &'ctx TypeDecls,
     pub fun_context: &'ctx FD,
-    pub const_context: &'ctx CD,
+    pub global_context: &'ctx CD,
     pub type_vars: &'ctx TypeVarId::Vector<TypeVar>,
     pub vars: &'ctx VarId::Vector<Var>,
 }
 
-type AstFormatter<'ctx> = GAstFormatter<'ctx, FunDecls, ConstDecls>;
+type AstFormatter<'ctx> = GAstFormatter<'ctx, FunDecls, GlobalDecls>;
 
 impl<'ctx> Formatter<FunDeclId::Id> for AstFormatter<'ctx> {
     fn format_object(&self, id: FunDeclId::Id) -> String {
@@ -801,9 +801,9 @@ impl<'ctx> Formatter<&Terminator> for AstFormatter<'ctx> {
     }
 }
 
-impl<'ctx> Formatter<ConstDeclId::Id> for AstFormatter<'ctx> {
-    fn format_object(&self, id: ConstDeclId::Id) -> String {
-        let c = self.const_context.get(id).unwrap();
+impl<'ctx> Formatter<GlobalDeclId::Id> for AstFormatter<'ctx> {
+    fn format_object(&self, id: GlobalDeclId::Id) -> String {
+        let c = self.global_context.get(id).unwrap();
         c.name.to_string()
     }
 }
@@ -837,7 +837,7 @@ impl<'ctx, FD, CD> GAstFormatter<'ctx, FD, CD> {
         GAstFormatter {
             type_context,
             fun_context,
-            const_context,
+            global_context: const_context,
             type_vars,
             vars,
         }
@@ -929,7 +929,7 @@ impl FunDecl {
         &self,
         ty_ctx: &'ctx TypeDecls,
         fun_ctx: &'ctx FunDecls,
-        const_ctx: &'ctx ConstDecls,
+        const_ctx: &'ctx GlobalDecls,
     ) -> String {
         // Initialize the contexts
         let fun_sig_ctx = FunSigFormatter {
@@ -958,12 +958,12 @@ impl FunDecl {
     }
 }
 
-impl ConstDecl {
+impl GlobalDecl {
     pub fn fmt_with_defs<'ctx>(
         &self,
         ty_ctx: &'ctx TypeDecls,
         fun_ctx: &'ctx FunDecls,
-        const_ctx: &'ctx ConstDecls,
+        const_ctx: &'ctx GlobalDecls,
     ) -> String {
         // We cheat a bit: if there is a body, we take its locals, otherwise
         // we use []:

--- a/charon/src/im_to_llbc.rs
+++ b/charon/src/im_to_llbc.rs
@@ -19,7 +19,7 @@
 //! many nodes and edges).
 
 use crate::im_ast::FunDeclId;
-use crate::im_ast::{self as src, ConstDeclId};
+use crate::im_ast::{self as src, GlobalDeclId};
 use crate::llbc_ast as tgt;
 use crate::types::TypeDecls;
 use crate::values as v;
@@ -1779,7 +1779,7 @@ fn translate_function(
     type_defs: &TypeDecls,
     src_defs: &src::FunDecls,
     src_def_id: FunDeclId::Id,
-    const_defs: &src::ConstDecls,
+    const_defs: &src::GlobalDecls,
 ) -> tgt::FunDecl {
     // Retrieve the function definition
     let src_def = src_defs.get(src_def_id).unwrap();
@@ -1860,8 +1860,8 @@ fn translate_function(
 fn translate_constant(
     no_code_duplication: bool,
     type_defs: &TypeDecls,
-    const_defs: &src::ConstDecls,
-    const_id: ConstDeclId::Id,
+    const_defs: &src::GlobalDecls,
+    const_id: GlobalDeclId::Id,
     fun_defs: &src::FunDecls,
 ) -> tgt::ConstDecl {
     // Retrieve the constant definition
@@ -1926,10 +1926,10 @@ pub fn translate_functions(
     no_code_duplication: bool,
     type_defs: &TypeDecls,
     in_funs: &src::FunDecls,
-    in_consts: &src::ConstDecls,
+    in_consts: &src::GlobalDecls,
 ) -> Defs {
     let mut out_funs = FunDeclId::Vector::new();
-    let mut out_consts = ConstDeclId::Vector::new();
+    let mut out_consts = GlobalDeclId::Vector::new();
 
     // Translate the bodies one at a time
     for fun_id in in_funs.iter_indices() {

--- a/charon/src/im_to_llbc.rs
+++ b/charon/src/im_to_llbc.rs
@@ -34,12 +34,12 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::iter::FromIterator;
 
-pub type Defs = (tgt::FunDecls, tgt::ConstDecls);
+pub type Defs = (tgt::FunDecls, tgt::GlobalDecls);
 
 /// Control-Flow Graph
 type Cfg = DiGraphMap<src::BlockId::Id, ()>;
 
-fn get_block_targets(body: &src::FunBody, block_id: src::BlockId::Id) -> Vec<src::BlockId::Id> {
+fn get_block_targets(body: &src::ExprBody, block_id: src::BlockId::Id) -> Vec<src::BlockId::Id> {
     let block = body.body.get(block_id).unwrap();
 
     match &block.terminator {
@@ -99,7 +99,7 @@ struct CfgInfo {
 
 /// Build the CFGs (the "regular" CFG and the CFG without backward edges) and
 /// compute some information like the loop entries and the switch blocks.
-fn build_cfg_partial_info(body: &src::FunBody) -> CfgPartialInfo {
+fn build_cfg_partial_info(body: &src::ExprBody) -> CfgPartialInfo {
     let mut cfg = CfgPartialInfo {
         cfg: Cfg::new(),
         cfg_no_be: Cfg::new(),
@@ -128,7 +128,7 @@ fn build_cfg_partial_info(body: &src::FunBody) -> CfgPartialInfo {
     cfg
 }
 
-fn block_is_switch(body: &src::FunBody, block_id: src::BlockId::Id) -> bool {
+fn block_is_switch(body: &src::ExprBody, block_id: src::BlockId::Id) -> bool {
     let block = body.body.get(block_id).unwrap();
     block.terminator.is_switch()
 }
@@ -137,7 +137,7 @@ fn build_cfg_partial_info_edges(
     cfg: &mut CfgPartialInfo,
     ancestors: &im::HashSet<src::BlockId::Id>,
     explored: &mut im::HashSet<src::BlockId::Id>,
-    body: &src::FunBody,
+    body: &src::ExprBody,
     block_id: src::BlockId::Id,
 ) {
     // Check if we already explored the current node
@@ -1326,7 +1326,7 @@ enum GotoKind {
 fn translate_child_block(
     no_code_duplication: bool,
     cfg: &CfgInfo,
-    body: &src::FunBody,
+    body: &src::ExprBody,
     exits_info: &ExitInfo,
     parent_loops: Vector<src::BlockId::Id>,
     switch_exit_blocks: &im::HashSet<src::BlockId::Id>,
@@ -1378,7 +1378,7 @@ fn translate_statement(st: &src::Statement) -> Option<tgt::Statement> {
 fn translate_terminator(
     no_code_duplication: bool,
     cfg: &CfgInfo,
-    body: &src::FunBody,
+    body: &src::ExprBody,
     exits_info: &ExitInfo,
     parent_loops: Vector<src::BlockId::Id>,
     switch_exit_blocks: &im::HashSet<src::BlockId::Id>,
@@ -1621,7 +1621,7 @@ fn is_terminal_explore(num_loops: usize, st: &tgt::Statement) -> bool {
 fn translate_block(
     no_code_duplication: bool,
     cfg: &CfgInfo,
-    body: &src::FunBody,
+    body: &src::ExprBody,
     exits_info: &ExitInfo,
     parent_loops: Vector<src::BlockId::Id>,
     switch_exit_blocks: &im::HashSet<src::BlockId::Id>,
@@ -1774,145 +1774,98 @@ fn translate_block(
 }
 
 /// [type_defs]: this parameter is used for pretty-printing purposes
+fn translate_body(no_code_duplication: bool, src_body: &src::ExprBody) -> tgt::ExprBody {
+    // Explore the function body to create the control-flow graph without backward
+    // edges, and identify the loop entries (which are destinations of backward edges).
+    let cfg_info = build_cfg_partial_info(src_body);
+    let cfg_info = compute_cfg_info_from_partial(cfg_info);
+
+    // Find the exit block for all the loops and switches, if such an exit point
+    // exists.
+    let exits_info = compute_loop_switch_exits(&cfg_info);
+
+    // Debugging
+    trace!("exits map:\n{:?}", exits_info);
+
+    // Translate the body by reconstructing the loops and the
+    // conditional branchings.
+    // Note that we shouldn't get `None`.
+    let mut explored = HashSet::new();
+    let stmt = translate_block(
+        no_code_duplication,
+        &cfg_info,
+        src_body,
+        &exits_info,
+        Vector::new(),
+        &im::HashSet::new(),
+        &mut explored,
+        src::BlockId::ZERO,
+    )
+    .unwrap();
+
+    // Sanity: check that we translated all the blocks
+    for (bid, _) in src_body.body.iter_indexed_values() {
+        assert!(explored.contains(&bid));
+    }
+
+    tgt::ExprBody {
+        arg_count: src_body.arg_count,
+        locals: src_body.locals.clone(),
+        body: stmt,
+    }
+}
+
+/// [type_defs] [global_defs]: this parameter is used for pretty-printing purposes
 fn translate_function(
     no_code_duplication: bool,
     type_defs: &TypeDecls,
     src_defs: &src::FunDecls,
     src_def_id: FunDeclId::Id,
-    const_defs: &src::GlobalDecls,
+    global_defs: &src::GlobalDecls,
 ) -> tgt::FunDecl {
     // Retrieve the function definition
     let src_def = src_defs.get(src_def_id).unwrap();
     trace!(
         "# Reconstructing: {}\n\n{}",
         src_def.name,
-        src_def.fmt_with_defs(&type_defs, &src_defs, &const_defs)
+        src_def.fmt_with_defs(&type_defs, &src_defs, &global_defs)
     );
-
-    // Translate the body if the function is transparent, ignore otherwise
-    // (if the function is opaque)
-    let body = match &src_def.body {
-        Option::Some(src_body) => {
-            // Explore the function body to create the control-flow graph without backward
-            // edges, and identify the loop entries (which are destinations of backward edges).
-            let cfg_info = build_cfg_partial_info(src_body);
-            let cfg_info = compute_cfg_info_from_partial(cfg_info);
-
-            // Find the exit block for all the loops and switches, if such an exit point
-            // exists.
-            let exits_info = compute_loop_switch_exits(&cfg_info);
-
-            // Debugging
-            trace!("exits map:\n{:?}", exits_info);
-
-            // Translate the body by reconstructing the loops and the
-            // conditional branchings.
-            // Note that we shouldn't get `None`.
-            let mut explored = HashSet::new();
-            let body_exp = translate_block(
-                no_code_duplication,
-                &cfg_info,
-                src_body,
-                &exits_info,
-                Vector::new(),
-                &im::HashSet::new(),
-                &mut explored,
-                src::BlockId::ZERO,
-            )
-            .unwrap();
-
-            // Sanity: check that we translated all the blocks
-            for (bid, _) in src_body.body.iter_indexed_values() {
-                assert!(explored.contains(&bid));
-            }
-
-            // Create the new body
-            let src::FunBody {
-                arg_count,
-                locals,
-                body: _,
-            } = src_body;
-
-            let body = tgt::FunBody {
-                arg_count: *arg_count,
-                locals: locals.clone(),
-                body: body_exp,
-            };
-
-            Option::Some(body)
-        }
-        Option::None => {
-            // Opaque definition
-            Option::None
-        }
-    };
 
     // Return the translated definition
     tgt::FunDecl {
         def_id: src_def.def_id,
         name: src_def.name.clone(),
         signature: src_def.signature.clone(),
-        body,
+        body: src_def
+            .body
+            .as_ref()
+            .map(|b| translate_body(no_code_duplication, b)),
     }
 }
 
-/// TODO: As always, refactor with [translate_function].
-fn translate_constant(
+fn translate_global(
     no_code_duplication: bool,
     type_defs: &TypeDecls,
-    const_defs: &src::GlobalDecls,
-    const_id: GlobalDeclId::Id,
+    global_defs: &src::GlobalDecls,
+    global_id: GlobalDeclId::Id,
     fun_defs: &src::FunDecls,
-) -> tgt::ConstDecl {
-    // Retrieve the constant definition
-    let const_def = const_defs.get(const_id).unwrap();
+) -> tgt::GlobalDecl {
+    // Retrieve the global definition
+    let src_def = global_defs.get(global_id).unwrap();
     trace!(
         "# Reconstructing: {}\n\n{}",
-        const_def.name,
-        const_def.fmt_with_defs(&type_defs, &fun_defs, &const_defs)
+        src_def.name,
+        src_def.fmt_with_defs(&type_defs, &fun_defs, &global_defs)
     );
 
-    tgt::ConstDecl {
-        def_id: const_def.def_id,
-        name: const_def.name.clone(),
-        type_: const_def.type_.clone(),
-        body: const_def.body.as_ref().map(|src| {
-            // TODO: Refactor the CFG arguments to avoid cloning.
-            let cfg_arg = src::FunBody {
-                arg_count: 0,
-                locals: src.locals.clone(),
-                body: src.body.clone(),
-            };
-
-            // The remaining code is the same as for functions translation.
-
-            let cfg_info = build_cfg_partial_info(&cfg_arg);
-            let cfg_info = compute_cfg_info_from_partial(cfg_info);
-            let exits_info = compute_loop_switch_exits(&cfg_info);
-
-            trace!("exits map:\n{:?}", exits_info);
-            let mut explored = HashSet::new();
-            let body_exp = translate_block(
-                no_code_duplication,
-                &cfg_info,
-                &cfg_arg,
-                &exits_info,
-                Vector::new(),
-                &im::HashSet::new(),
-                &mut explored,
-                src::BlockId::ZERO,
-            )
-            .unwrap();
-
-            for (bid, _) in src.body.iter_indexed_values() {
-                assert!(explored.contains(&bid));
-            }
-
-            tgt::ConstBody {
-                locals: src.locals.clone(),
-                body: body_exp,
-            }
-        }),
+    tgt::GlobalDecl {
+        def_id: src_def.def_id,
+        name: src_def.name.clone(),
+        type_: src_def.type_.clone(),
+        body: src_def
+            .body
+            .as_ref()
+            .map(|b| translate_body(no_code_duplication, b)),
     }
 }
 
@@ -1926,10 +1879,10 @@ pub fn translate_functions(
     no_code_duplication: bool,
     type_defs: &TypeDecls,
     in_funs: &src::FunDecls,
-    in_consts: &src::GlobalDecls,
+    in_globals: &src::GlobalDecls,
 ) -> Defs {
     let mut out_funs = FunDeclId::Vector::new();
-    let mut out_consts = GlobalDeclId::Vector::new();
+    let mut out_globals = GlobalDeclId::Vector::new();
 
     // Translate the bodies one at a time
     for fun_id in in_funs.iter_indices() {
@@ -1938,15 +1891,15 @@ pub fn translate_functions(
             type_defs,
             in_funs,
             fun_id,
-            in_consts,
+            in_globals,
         ));
     }
-    for const_id in in_consts.iter_indices() {
-        out_consts.push_back(translate_constant(
+    for global_id in in_globals.iter_indices() {
+        out_globals.push_back(translate_global(
             no_code_duplication,
             type_defs,
-            in_consts,
-            const_id,
+            in_globals,
+            global_id,
             in_funs,
         ));
     }
@@ -1956,17 +1909,17 @@ pub fn translate_functions(
         trace!(
             "# Signature:\n{}\n\n# Function definition:\n{}\n",
             fun.signature.fmt_with_defs(&type_defs),
-            fun.fmt_with_defs(&type_defs, &out_funs, &out_consts)
+            fun.fmt_with_defs(&type_defs, &out_funs, &out_globals)
         );
     }
-    // Print the constants
-    for fun in &out_funs {
+    // Print the global variables
+    for global in &out_globals {
         trace!(
-            "# Signature:\n{}\n\n# Function definition:\n{}\n",
-            fun.signature.fmt_with_defs(&type_defs),
-            fun.fmt_with_defs(&type_defs, &out_funs, &out_consts)
+            "# Type:\n{:?}\n\n# Global definition:\n{}\n",
+            global.type_,
+            global.fmt_with_defs(&type_defs, &out_funs, &out_globals)
         );
     }
 
-    (out_funs, out_consts)
+    (out_funs, out_globals)
 }

--- a/charon/src/llbc_ast.rs
+++ b/charon/src/llbc_ast.rs
@@ -89,12 +89,10 @@ pub enum SwitchTargets {
     ),
 }
 
-/// A function body & declaration
-pub type FunBody = GFunBody<Statement>;
+pub type ExprBody = GExprBody<Statement>;
+
 pub type FunDecl = GFunDecl<Statement>;
 pub type FunDecls = FunDeclId::Vector<FunDecl>;
 
-/// A constant body & declaration
-pub type ConstBody = GGlobalBody<Statement>;
-pub type ConstDecl = GGlobalDecl<Statement>;
-pub type ConstDecls = GlobalDeclId::Vector<ConstDecl>;
+pub type GlobalDecl = GGlobalDecl<Statement>;
+pub type GlobalDecls = GlobalDeclId::Vector<GlobalDecl>;

--- a/charon/src/llbc_ast.rs
+++ b/charon/src/llbc_ast.rs
@@ -95,6 +95,6 @@ pub type FunDecl = GFunDecl<Statement>;
 pub type FunDecls = FunDeclId::Vector<FunDecl>;
 
 /// A constant body & declaration
-pub type ConstBody = GConstBody<Statement>;
-pub type ConstDecl = GConstDecl<Statement>;
-pub type ConstDecls = ConstDeclId::Vector<ConstDecl>;
+pub type ConstBody = GGlobalBody<Statement>;
+pub type ConstDecl = GGlobalDecl<Statement>;
+pub type ConstDecls = GlobalDeclId::Vector<ConstDecl>;

--- a/charon/src/llbc_ast_utils.rs
+++ b/charon/src/llbc_ast_utils.rs
@@ -4,7 +4,7 @@
 use crate::expressions::{Operand, Place, Rvalue};
 use crate::formatter::Formatter;
 use crate::im_ast::{fmt_call, FunDeclId, FunSigFormatter, GAstFormatter, GlobalDeclId, TAB_INCR};
-use crate::llbc_ast::{Call, ConstDecl, ConstDecls, FunDecl, FunDecls, Statement, SwitchTargets};
+use crate::llbc_ast::{Call, FunDecl, FunDecls, GlobalDecl, GlobalDecls, Statement, SwitchTargets};
 use crate::types::*;
 use crate::values::*;
 use crate::{common::*, id_vector};
@@ -192,7 +192,7 @@ impl Statement {
     }
 }
 
-type AstFormatter<'ctx> = GAstFormatter<'ctx, FunDecls, ConstDecls>;
+type AstFormatter<'ctx> = GAstFormatter<'ctx, FunDecls, GlobalDecls>;
 
 impl<'ctx> Formatter<FunDeclId::Id> for AstFormatter<'ctx> {
     fn format_object(&self, id: FunDeclId::Id) -> String {
@@ -237,7 +237,7 @@ impl FunDecl {
         &self,
         ty_ctx: &'ctx TypeDecls,
         fun_ctx: &'ctx FunDecls,
-        const_ctx: &'ctx ConstDecls,
+        const_ctx: &'ctx GlobalDecls,
     ) -> String {
         // Initialize the contexts
         let fun_sig_ctx = FunSigFormatter {
@@ -266,12 +266,12 @@ impl FunDecl {
     }
 }
 
-impl ConstDecl {
+impl GlobalDecl {
     pub fn fmt_with_defs<'ctx>(
         &self,
         ty_ctx: &'ctx TypeDecls,
         fun_ctx: &'ctx FunDecls,
-        const_ctx: &'ctx ConstDecls,
+        const_ctx: &'ctx GlobalDecls,
     ) -> String {
         // We cheat a bit: if there is a body, we take its locals, otherwise
         // we use []:

--- a/charon/src/llbc_ast_utils.rs
+++ b/charon/src/llbc_ast_utils.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 use crate::expressions::{Operand, Place, Rvalue};
 use crate::formatter::Formatter;
-use crate::im_ast::{fmt_call, ConstDeclId, FunDeclId, FunSigFormatter, GAstFormatter, TAB_INCR};
+use crate::im_ast::{fmt_call, FunDeclId, FunSigFormatter, GAstFormatter, GlobalDeclId, TAB_INCR};
 use crate::llbc_ast::{Call, ConstDecl, ConstDecls, FunDecl, FunDecls, Statement, SwitchTargets};
 use crate::types::*;
 use crate::values::*;
@@ -70,7 +70,7 @@ impl Statement {
             + Formatter<TypeDeclId::Id>
             + Formatter<&'a ErasedRegion>
             + Formatter<FunDeclId::Id>
-            + Formatter<ConstDeclId::Id>
+            + Formatter<GlobalDeclId::Id>
             + Formatter<(TypeDeclId::Id, VariantId::Id)>
             + Formatter<(TypeDeclId::Id, Option<VariantId::Id>, FieldId::Id)>,
     {
@@ -201,9 +201,9 @@ impl<'ctx> Formatter<FunDeclId::Id> for AstFormatter<'ctx> {
     }
 }
 
-impl<'ctx> Formatter<ConstDeclId::Id> for AstFormatter<'ctx> {
-    fn format_object(&self, id: ConstDeclId::Id) -> String {
-        let c = self.const_context.get(id).unwrap();
+impl<'ctx> Formatter<GlobalDeclId::Id> for AstFormatter<'ctx> {
+    fn format_object(&self, id: GlobalDeclId::Id) -> String {
+        let c = self.global_context.get(id).unwrap();
         c.name.to_string()
     }
 }

--- a/charon/src/llbc_export.rs
+++ b/charon/src/llbc_export.rs
@@ -38,7 +38,7 @@ struct ModSerializer<'a> {
     declarations: DeclarationsSerializer<'a>,
     types: &'a TypeDeclId::Vector<TypeDecl>,
     functions: &'a FunDeclId::Vector<FunDecl>,
-    constants: &'a GlobalDeclId::Vector<ConstDecl>,
+    globals: &'a GlobalDeclId::Vector<GlobalDecl>,
 }
 
 /// Export the translated definitions to a JSON file.
@@ -47,7 +47,7 @@ pub fn export(
     ordered_decls: &OrderedDecls,
     type_defs: &TypeDecls,
     fun_defs: &FunDecls,
-    const_defs: &ConstDecls,
+    global_defs: &GlobalDecls,
     dest_dir: &Option<PathBuf>,
     sourcefile: &PathBuf,
 ) -> Result<()> {
@@ -81,7 +81,7 @@ pub fn export(
         declarations: VecSW::new(&ordered_decls.decls),
         types: &type_defs.types,
         functions: &fun_defs,
-        constants: &const_defs,
+        globals: &global_defs,
     };
 
     // Create the directory, if necessary (note that if the target directory

--- a/charon/src/llbc_export.rs
+++ b/charon/src/llbc_export.rs
@@ -1,6 +1,6 @@
 use crate::common::*;
-use crate::im_ast::ConstDeclId;
 use crate::im_ast::FunDeclId;
+use crate::im_ast::GlobalDeclId;
 use crate::llbc_ast::*;
 use crate::rust_to_local_ids::*;
 use crate::types::*;
@@ -38,7 +38,7 @@ struct ModSerializer<'a> {
     declarations: DeclarationsSerializer<'a>,
     types: &'a TypeDeclId::Vector<TypeDecl>,
     functions: &'a FunDeclId::Vector<FunDecl>,
-    constants: &'a ConstDeclId::Vector<ConstDecl>,
+    constants: &'a GlobalDeclId::Vector<ConstDecl>,
 }
 
 /// Export the translated definitions to a JSON file.

--- a/charon/src/main.rs
+++ b/charon/src/main.rs
@@ -829,7 +829,7 @@ fn translate(sess: &Session, tcx: TyCtxt, internal: &ToInternal) -> Result<(), (
     // # Step 5: translate the functions to IM (our Internal representation of MIR).
     // Note that from now onwards, both type and function definitions have been
     // translated to our internal ASTs: we don't interact with rustc anymore.
-    let (fun_defs, const_defs) = translate_functions_to_im::translate_functions(
+    let (fun_defs, global_defs) = translate_functions_to_im::translate_functions(
         tcx,
         &ordered_decls,
         &types_constraints,
@@ -838,11 +838,11 @@ fn translate(sess: &Session, tcx: TyCtxt, internal: &ToInternal) -> Result<(), (
 
     // # Step 6: go from IM to LLBC (Low-Level Borrow Calculus) by reconstructing
     // the control flow.
-    let (llbc_funs, llbc_consts) = im_to_llbc::translate_functions(
+    let (llbc_funs, llbc_globals) = im_to_llbc::translate_functions(
         internal.no_code_duplication,
         &type_defs,
         &fun_defs,
-        &const_defs,
+        &global_defs,
     );
 
     //
@@ -861,7 +861,7 @@ fn translate(sess: &Session, tcx: TyCtxt, internal: &ToInternal) -> Result<(), (
     for def in &llbc_funs {
         trace!(
             "# After binop simplification:\n{}\n",
-            def.fmt_with_defs(&type_defs, &llbc_funs, &llbc_consts)
+            def.fmt_with_defs(&type_defs, &llbc_funs, &llbc_globals)
         );
     }
 
@@ -871,7 +871,7 @@ fn translate(sess: &Session, tcx: TyCtxt, internal: &ToInternal) -> Result<(), (
     for def in &llbc_funs {
         trace!(
             "# After asserts reconstruction:\n{}\n",
-            def.fmt_with_defs(&type_defs, &llbc_funs, &llbc_consts)
+            def.fmt_with_defs(&type_defs, &llbc_funs, &llbc_globals)
         );
     }
 
@@ -901,7 +901,7 @@ fn translate(sess: &Session, tcx: TyCtxt, internal: &ToInternal) -> Result<(), (
         &ordered_decls,
         &type_defs,
         &llbc_funs,
-        &llbc_consts,
+        &llbc_globals,
         &internal.dest_dir,
         &internal.source_file,
     )?;

--- a/charon/src/main.rs
+++ b/charon/src/main.rs
@@ -1,5 +1,6 @@
 #![feature(rustc_private, register_tool)]
 #![feature(box_syntax, box_patterns)]
+#![feature(is_some_with)]
 #![feature(cell_leak)] // For Ref::leak
 // For rustdoc: prevents overflows
 #![recursion_limit = "256"]
@@ -807,7 +808,7 @@ fn translate(sess: &Session, tcx: TyCtxt, internal: &ToInternal) -> Result<(), (
     // so we just ignore them).
     let crate_info = register::CrateInfo {
         crate_name: crate_name.clone(),
-        opaque: HashSet::from_iter(internal.opaque_modules.clone().into_iter()),
+        opaque_mods: HashSet::from_iter(internal.opaque_modules.clone().into_iter()),
     };
     let registered_decls = register::register_crate(&crate_info, sess, tcx)?;
 

--- a/charon/src/names.rs
+++ b/charon/src/names.rs
@@ -59,5 +59,5 @@ pub type ModuleName = Name;
 pub type TypeName = Name;
 pub type ItemName = Name;
 pub type FunName = Name;
-pub type ConstName = Name;
+pub type GlobalName = Name;
 pub type HirItemName = Name;

--- a/charon/src/names_utils.rs
+++ b/charon/src/names_utils.rs
@@ -287,7 +287,7 @@ pub fn function_def_id_to_name(tcx: TyCtxt, def_id: DefId) -> FunName {
     item_def_id_to_name(tcx, def_id)
 }
 
-pub fn constant_def_id_to_name(tcx: TyCtxt, def_id: DefId) -> GlobalName {
+pub fn global_def_id_to_name(tcx: TyCtxt, def_id: DefId) -> GlobalName {
     item_def_id_to_name(tcx, def_id)
 }
 

--- a/charon/src/names_utils.rs
+++ b/charon/src/names_utils.rs
@@ -287,7 +287,7 @@ pub fn function_def_id_to_name(tcx: TyCtxt, def_id: DefId) -> FunName {
     item_def_id_to_name(tcx, def_id)
 }
 
-pub fn constant_def_id_to_name(tcx: TyCtxt, def_id: DefId) -> ConstName {
+pub fn constant_def_id_to_name(tcx: TyCtxt, def_id: DefId) -> GlobalName {
     item_def_id_to_name(tcx, def_id)
 }
 
@@ -325,6 +325,7 @@ pub fn hir_item_to_name(tcx: TyCtxt, item: &Item) -> Option<HirItemName> {
         | ItemKind::Impl(_)
         | ItemKind::Mod(_)
         | ItemKind::Const(_, _)
+        | ItemKind::Static(_, _, _)
         | ItemKind::Macro(_) => Option::Some(item_def_id_to_name(tcx, def_id)),
         _ => {
             unimplemented!("{:?}", item.kind);

--- a/charon/src/register.rs
+++ b/charon/src/register.rs
@@ -26,133 +26,101 @@ fn is_fn_decl(item: &Item) -> bool {
 
 pub struct CrateInfo {
     pub crate_name: String,
-    /// The set of opaque modules
-    pub opaque: HashSet<String>,
+    pub opaque_mods: HashSet<String>,
 }
 
-pub type TypeDependencies = LinkedHashSet<DefId>;
-pub type FunDependencies = LinkedHashSet<DefId>;
-pub type ConstDependencies = LinkedHashSet<DefId>;
+/// All kind of supported Rust top-level declarations.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DeclKind {
+    Type,
+    Function,
+    Const,
+    Static,
+}
 
-/// A registered type declaration.
-/// Simply contains the item id and its dependencies.
+pub type DeclDependencies = LinkedHashSet<DefId>;
+
+/// A registered declaration, listing its dependencies.
 #[derive(Debug)]
-pub struct RegisteredTypeDeclaration {
-    pub type_id: DefId,
-    /// The set of type dependencies. It can contain local def ids as well as
-    /// external def ids.
-    pub deps: TypeDependencies,
+pub struct Declaration {
+    // The declaration may be local or extern (id.is_local()).
+    pub id: DefId,
+    pub kind: DeclKind,
+    // The IDs of the declarations its body depends on.
+    // None if opaque (it means that the body is unavailable).
+    pub deps: Option<DeclDependencies>,
 }
 
-impl RegisteredTypeDeclaration {
-    pub fn new(id: DefId) -> RegisteredTypeDeclaration {
-        return RegisteredTypeDeclaration {
-            type_id: id,
-            deps: LinkedHashSet::new(),
-        };
+impl Declaration {
+    fn new_opaque(id: DefId, kind: DeclKind) -> Declaration {
+        Declaration {
+            id,
+            kind,
+            deps: None,
+        }
+    }
+
+    fn new_visible(id: DefId, kind: DeclKind, deps: LinkedHashSet<DefId>) -> Declaration {
+        Declaration {
+            id,
+            kind,
+            deps: Some(deps),
+        }
+    }
+
+    pub fn is_local(&self) -> bool {
+        self.id.is_local()
+    }
+
+    pub fn is_visible(&self) -> bool {
+        self.deps.is_some()
     }
 }
 
-/// A registered function declaration.
-/// Simply contains the item id and its dependencies.
-#[derive(Debug)]
-pub struct RegisteredFunDeclaration {
-    pub fun_id: DefId,
-    /// The set of type dependencies. It can contain local def ids as well as
-    /// external def ids.
-    pub deps_tys: TypeDependencies,
-    /// The set of function dependencies. It can contain local def ids as well as
-    /// external def ids.
-    pub deps_funs: FunDependencies,
-    /// The set of constant dependencies. It can contain local def ids as well as
-    /// external def ids.
-    pub deps_consts: ConstDependencies,
+pub type RegisteredDeclarations = LinkedHashMap<DefId, Declaration>;
+
+/// The declarations register adds declarations in two steps :
+/// It must first add their id before adding the whole declaration.
+/// This is done to prevent vicious circles while registering declarations.
+struct DeclarationsRegister {
+    decl_ids: LinkedHashSet<DefId>,
+    decls: RegisteredDeclarations,
 }
 
-impl RegisteredFunDeclaration {
-    pub fn new(id: DefId) -> RegisteredFunDeclaration {
-        return RegisteredFunDeclaration {
-            fun_id: id,
-            deps_tys: LinkedHashSet::new(),
-            deps_funs: LinkedHashSet::new(),
-            deps_consts: LinkedHashSet::new(),
-        };
+impl DeclarationsRegister {
+    fn new() -> DeclarationsRegister {
+        DeclarationsRegister {
+            decl_ids: LinkedHashSet::new(),
+            decls: RegisteredDeclarations::new(),
+        }
     }
-}
 
-/// A registered constant declaration.
-/// Simply contains the item id and its dependencies.
-#[derive(Debug)]
-pub struct RegisteredConstDeclaration {
-    pub const_id: DefId,
-    /// The set of type dependencies. It can contain local def ids as well as
-    /// external def ids.
-    pub deps_tys: TypeDependencies,
-    /// The set of function dependencies. It can contain local def ids as well as
-    /// external def ids.
-    pub deps_funs: FunDependencies,
-    /// The set of constant dependencies. It can contain local def ids as well as
-    /// external def ids.
-    pub deps_consts: ConstDependencies,
-}
-
-impl RegisteredConstDeclaration {
-    pub fn new(id: DefId) -> RegisteredConstDeclaration {
-        return RegisteredConstDeclaration {
-            const_id: id,
-            deps_tys: LinkedHashSet::new(),
-            deps_funs: LinkedHashSet::new(),
-            deps_consts: LinkedHashSet::new(),
-        };
+    fn knows(&self, id: &DefId) -> bool {
+        self.decl_ids.contains(id)
     }
-}
 
-/// Contains the declarations registered in the first pass of the translation.
-/// This pass is used to build the local dependency graph between the declarations,
-/// in order to know in which order to translate them, and detect the cycles
-/// (i.e.: the mutually recursive definitions).
-#[derive(Debug)]
-pub struct RegisteredDeclarations {
-    /// All the def ids of the declarations to be translated, in the order in
-    /// which we registered them. This set can only contain local def ids.
-    pub decls: LinkedHashSet<DefId>,
+    fn add_id(&mut self, id: DefId) {
+        // TODO: This is a new assertion, it may fail for a good reason I'm not aware of.
+        assert!(self.decl_ids.insert(id), "Already knows {:?}", id);
+    }
 
-    /// All the type declarations to be translated, and their local
-    /// dependencies.
-    pub types: LinkedHashMap<DefId, RegisteredTypeDeclaration>,
+    fn add(&mut self, decl: Declaration) {
+        let id = decl.id;
+        assert!(self.knows(&id));
 
-    /// All the opaque type declarations (local types, but found in modules
-    /// that were marked as opaque). Does not include the non-local types.
-    pub opaque_types: HashSet<DefId>,
+        assert!(
+            self.decls.insert(id, decl).is_none(),
+            "Registered the same declaration {:?} twice",
+            id
+        );
+    }
 
-    /// All the function declarations to be translated, and their local
-    /// dependencies.
-    pub funs: LinkedHashMap<DefId, RegisteredFunDeclaration>,
-
-    /// All the opaque function declarations (local function, but found in modules
-    /// that were marked as opaque). Does not include the non-local functions.
-    pub opaque_funs: HashSet<DefId>,
-
-    /// All the constant declarations to be translated, and their local
-    /// dependencies.
-    pub consts: LinkedHashMap<DefId, RegisteredConstDeclaration>,
-
-    /// All the opaque constant declarations (local constant, but found in modules
-    /// that were marked as opaque). Does not include the non-local constants.
-    pub opaque_consts: HashSet<DefId>,
-}
-
-impl RegisteredDeclarations {
-    pub fn new() -> RegisteredDeclarations {
-        return RegisteredDeclarations {
-            decls: LinkedHashSet::new(),
-            types: LinkedHashMap::new(),
-            opaque_types: HashSet::new(),
-            funs: LinkedHashMap::new(),
-            opaque_funs: HashSet::new(),
-            consts: LinkedHashMap::new(),
-            opaque_consts: HashSet::new(),
-        };
+    fn get_declarations(self) -> RegisteredDeclarations {
+        // TODO: This is a new assertion, it may fail for a good reason I'm not aware of.
+        for id in self.decl_ids.iter() {
+            assert!(self.decls.contains_key(id), "Did not registered {:?}", id);
+        }
+        self.decls
     }
 }
 
@@ -165,7 +133,7 @@ impl RegisteredDeclarations {
 /// the def_id to the list of registered ids.
 fn register_hir_type(
     crate_info: &CrateInfo,
-    rdecls: &mut RegisteredDeclarations,
+    rdecls: &mut DeclarationsRegister,
     sess: &Session,
     tcx: TyCtxt,
     item: &Item,
@@ -200,7 +168,7 @@ fn register_hir_type(
 /// explored def ids.
 fn register_local_adt(
     crate_info: &CrateInfo,
-    rdecls: &mut RegisteredDeclarations,
+    rdecls: &mut DeclarationsRegister,
     sess: &Session,
     tcx: TyCtxt,
     adt: &AdtDef,
@@ -223,73 +191,59 @@ fn register_local_adt(
 
     let type_id = adt.did;
 
-    // Initialize the type declaration that we will register (in particular,
-    // initialize the list of local dependencies to empty).
-    let mut rtype_decl = RegisteredTypeDeclaration::new(type_id);
-
     // We explore the type definition only if it is not in a module flagged
     // as opaque
     let name = type_def_id_to_name(tcx, adt.did);
-    if name.is_in_modules(&crate_info.crate_name, &crate_info.opaque) {
+    if name.is_in_modules(&crate_info.crate_name, &crate_info.opaque_mods) {
         // The type is opaque
         // Register it as having no dependencies (dependencies are introduced
         // by exploring the type definition, to check the types used in the fields).
-        rdecls.types.insert(type_id, rtype_decl);
-        rdecls.opaque_types.insert(type_id);
-        return Ok(());
-    } else {
-        // The type is not opaque
-
-        // Use a dummy substitution to instantiate the type parameters
-        let substs = rustc_middle::ty::subst::InternalSubsts::identity_for_item(tcx, adt.did);
-
-        // Explore all the variants. Note that we also explore the HIR to retrieve
-        // precise spans: for instance, to indicate which variant is problematic
-        // in case of an enum.
-        let hir_variants: &[rustc_hir::Variant] = match &item.kind {
-            ItemKind::Enum(enum_def, _) => enum_def.variants,
-            ItemKind::Struct(_, _) => {
-                // Nothing to return
-                &[]
-            }
-            _ => {
-                unreachable!()
-            }
-        };
-
-        let mut i = 0; // The index of the variant
-        for var_def in adt.variants.iter() {
-            trace!("var_def");
-            // Retrieve the most precise span (the span of the variant if this is an
-            // enum, the span of the whole ADT otherwise).
-            let var_span = if adt.is_enum() {
-                &hir_variants[i].span
-            } else {
-                &item.span
-            };
-
-            for field_def in var_def.fields.iter() {
-                trace!("field_def");
-                let ty = field_def.ty(tcx, substs);
-                trace!("ty");
-                register_mir_ty(
-                    crate_info,
-                    rdecls,
-                    sess,
-                    tcx,
-                    var_span,
-                    &mut rtype_decl.deps,
-                    &ty,
-                )?;
-            }
-
-            i += 1;
-        }
-
-        // Add the type declaration to the registered declarations
-        rdecls.types.insert(rtype_decl.type_id, rtype_decl);
+        rdecls.add(Declaration::new_opaque(type_id, DeclKind::Type));
         return Ok(());
     }
+
+    // Use a dummy substitution to instantiate the type parameters
+    let substs = rustc_middle::ty::subst::InternalSubsts::identity_for_item(tcx, adt.did);
+
+    // Explore all the variants. Note that we also explore the HIR to retrieve
+    // precise spans: for instance, to indicate which variant is problematic
+    // in case of an enum.
+    let hir_variants: &[rustc_hir::Variant] = match &item.kind {
+        ItemKind::Enum(enum_def, _) => enum_def.variants,
+        ItemKind::Struct(_, _) => {
+            // Nothing to return
+            &[]
+        }
+        _ => {
+            unreachable!()
+        }
+    };
+
+    let mut ty_deps = DeclDependencies::new();
+    let mut i = 0; // The index of the variant
+    for var_def in adt.variants.iter() {
+        trace!("var_def");
+        // Retrieve the most precise span (the span of the variant if this is an
+        // enum, the span of the whole ADT otherwise).
+        let var_span = if adt.is_enum() {
+            &hir_variants[i].span
+        } else {
+            &item.span
+        };
+
+        for field_def in var_def.fields.iter() {
+            trace!("field_def");
+            let ty = field_def.ty(tcx, substs);
+            trace!("ty");
+            register_mir_ty(crate_info, rdecls, sess, tcx, var_span, &mut ty_deps, &ty)?;
+        }
+
+        i += 1;
+    }
+
+    // Add the type declaration to the registered declarations
+    rdecls.add(Declaration::new_visible(type_id, DeclKind::Type, ty_deps));
+    Ok(())
 }
 
 /// Register a a non-local MIR ADT.
@@ -302,7 +256,7 @@ fn register_local_adt(
 /// enumeration).
 fn register_non_local_adt(
     _crate_info: &CrateInfo,
-    rdecls: &mut RegisteredDeclarations,
+    rdecls: &mut DeclarationsRegister,
     _sess: &Session,
     tcx: TyCtxt,
     adt: &AdtDef,
@@ -321,31 +275,27 @@ fn register_non_local_adt(
     let type_id = adt.did;
 
     // Check if registered
-    if rdecls.decls.contains(&type_id) {
+    if rdecls.knows(&type_id) {
         return Ok(());
     }
-    rdecls.decls.insert(type_id);
+    rdecls.add_id(type_id);
 
     // Check the generics - TODO: we check this here and in translate_types
     generics::check_type_generics(tcx, type_id);
 
     // Register the type as having no dependencies
-    let rtype_decl = RegisteredTypeDeclaration::new(type_id);
-
-    rdecls.types.insert(type_id, rtype_decl);
-    rdecls.opaque_types.insert(type_id);
-
+    rdecls.add(Declaration::new_opaque(type_id, DeclKind::Type));
     return Ok(());
 }
 
 /// Auxiliary function to register a list of type parameters.
 fn register_mir_substs<'tcx>(
     crate_info: &CrateInfo,
-    rdecls: &mut RegisteredDeclarations,
+    rdecls: &mut DeclarationsRegister,
     sess: &Session,
     tcx: TyCtxt,
     span: &Span,
-    deps: &mut TypeDependencies,
+    ty_deps: &mut LinkedHashSet<DefId>,
     used_params: Option<Vec<bool>>,
     substs: &rustc_middle::ty::subst::SubstsRef<'tcx>,
 ) -> Result<()> {
@@ -373,7 +323,7 @@ fn register_mir_substs<'tcx>(
     for param in params.into_iter() {
         match param.unpack() {
             rustc_middle::ty::subst::GenericArgKind::Type(param_ty) => {
-                register_mir_ty(crate_info, rdecls, sess, tcx, span, deps, &param_ty)?;
+                register_mir_ty(crate_info, rdecls, sess, tcx, span, ty_deps, &param_ty)?;
             }
             rustc_middle::ty::subst::GenericArgKind::Lifetime(_)
             | rustc_middle::ty::subst::GenericArgKind::Const(_) => {
@@ -389,11 +339,11 @@ fn register_mir_substs<'tcx>(
 /// before calling this function.
 fn register_mir_ty(
     crate_info: &CrateInfo,
-    rdecls: &mut RegisteredDeclarations,
+    rdecls: &mut DeclarationsRegister,
     sess: &Session,
     tcx: TyCtxt,
     span: &Span,
-    deps: &mut TypeDependencies,
+    ty_deps: &mut LinkedHashSet<DefId>,
     ty: &Ty,
 ) -> Result<()> {
     trace!("> ty: {:?}", ty);
@@ -441,7 +391,7 @@ fn register_mir_ty(
             // Add this ADT to the list of dependencies, only if it is not
             // primitive
             if !is_prim {
-                deps.insert(adt.did);
+                ty_deps.insert(adt.did);
             }
 
             // From now onwards, we do something different depending on
@@ -462,7 +412,7 @@ fn register_mir_ty(
                     sess,
                     tcx,
                     span,
-                    deps,
+                    ty_deps,
                     used_params,
                     substs,
                 )?;
@@ -482,19 +432,19 @@ fn register_mir_ty(
                     sess,
                     tcx,
                     span,
-                    deps,
+                    ty_deps,
                     Option::None,
                     substs,
                 )?;
 
                 // Explore the ADT, if we haven't already registered it
                 // Check if registered
-                if rdecls.decls.contains(&adt.did) {
+                if rdecls.knows(&adt.did) {
                     trace!("Adt already registered");
                     return Ok(());
                 }
                 trace!("Adt not registered");
-                rdecls.decls.insert(adt.did);
+                rdecls.add_id(adt.did);
 
                 // Register and explore
                 return register_local_adt(crate_info, rdecls, sess, tcx, adt);
@@ -503,25 +453,33 @@ fn register_mir_ty(
         TyKind::Array(ty, const_param) => {
             trace!("Array");
 
-            register_mir_ty(crate_info, rdecls, sess, tcx, span, deps, ty)?;
-            return register_mir_ty(crate_info, rdecls, sess, tcx, span, deps, &const_param.ty);
+            register_mir_ty(crate_info, rdecls, sess, tcx, span, ty_deps, ty)?;
+            return register_mir_ty(
+                crate_info,
+                rdecls,
+                sess,
+                tcx,
+                span,
+                ty_deps,
+                &const_param.ty,
+            );
         }
         TyKind::Slice(ty) => {
             trace!("Slice");
 
-            return register_mir_ty(crate_info, rdecls, sess, tcx, span, deps, ty);
+            return register_mir_ty(crate_info, rdecls, sess, tcx, span, ty_deps, ty);
         }
         TyKind::Ref(_, ty, _) => {
             trace!("Ref");
 
-            return register_mir_ty(crate_info, rdecls, sess, tcx, span, deps, ty);
+            return register_mir_ty(crate_info, rdecls, sess, tcx, span, ty_deps, ty);
         }
         TyKind::Tuple(substs) => {
             trace!("Tuple");
 
             for param in substs.iter() {
                 let param_ty = param.expect_ty();
-                register_mir_ty(crate_info, rdecls, sess, tcx, span, deps, &param_ty)?;
+                register_mir_ty(crate_info, rdecls, sess, tcx, span, ty_deps, &param_ty)?;
             }
 
             return Ok(());
@@ -558,7 +516,7 @@ fn register_mir_ty(
         TyKind::FnPtr(sig) => {
             trace!("FnPtr");
             for param_ty in sig.inputs_and_output().no_bound_vars().unwrap().iter() {
-                register_mir_ty(crate_info, rdecls, sess, tcx, span, deps, &param_ty)?;
+                register_mir_ty(crate_info, rdecls, sess, tcx, span, ty_deps, &param_ty)?;
             }
             return Ok(());
         }
@@ -678,7 +636,7 @@ fn visit_constant_dependencies<'tcx, F: FnMut(DefId)>(
 /// to check if the function has primitive support first.
 fn register_non_local_function(
     _crate_info: &CrateInfo,
-    rdecls: &mut RegisteredDeclarations,
+    rdecls: &mut DeclarationsRegister,
     _sess: &Session,
     tcx: TyCtxt,
     def_id: DefId,
@@ -692,38 +650,34 @@ fn register_non_local_function(
     }
 
     // Check if registered
-    if rdecls.decls.contains(&def_id) {
+    if rdecls.knows(&def_id) {
         return Ok(());
     }
-    rdecls.decls.insert(def_id);
+    rdecls.add_id(def_id);
 
     // Check the generics - TODO: we check this here and in translate_functions_to_im
     generics::check_function_generics(tcx, def_id);
 
     // Register the function as having no dependencies
-    let decl = RegisteredFunDeclaration::new(def_id);
-
-    rdecls.funs.insert(def_id, decl);
-    rdecls.opaque_funs.insert(def_id);
-
+    rdecls.add(Declaration::new_opaque(def_id, DeclKind::Function));
     return Ok(());
 }
 
 /// Register the identifiers found in a function body
 fn register_local_function_body(
     crate_info: &CrateInfo,
-    rdecls: &mut RegisteredDeclarations,
+    rdecls: &mut DeclarationsRegister,
     sess: &Session,
     tcx: TyCtxt,
     def_id: LocalDefId,
-    fn_decl: &mut RegisteredFunDeclaration,
+    fn_deps: &mut LinkedHashSet<DefId>,
 ) -> Result<()> {
     // Retrieve the MIR code
     let body = crate::get_mir::get_mir_for_def_id(tcx, def_id);
 
     for b in body.basic_blocks().iter() {
         visit_constant_dependencies(b, |c_id| {
-            if fn_decl.deps_consts.insert_if_absent(c_id) {
+            if fn_deps.insert_if_absent(c_id) {
                 let name = constant_def_id_to_name(tcx, c_id);
                 trace!("added fn {:?} dependency: {}", def_id, name);
             }
@@ -740,7 +694,7 @@ fn register_local_function_body(
             sess,
             tcx,
             &v.source_info.span,
-            &mut fn_decl.deps_tys,
+            fn_deps,
             &v.ty,
         )?;
     }
@@ -869,19 +823,12 @@ fn register_local_function_body(
                 // Add this function to the list of dependencies, only if
                 // it is non-primitive
                 if !is_prim {
-                    fn_decl.deps_funs.insert(fid);
+                    fn_deps.insert(fid);
                 }
 
                 // Register the types given as parameters.
                 register_mir_substs(
-                    crate_info,
-                    rdecls,
-                    sess,
-                    tcx,
-                    &fn_span,
-                    &mut fn_decl.deps_tys,
-                    used_types,
-                    &substs,
+                    crate_info, rdecls, sess, tcx, &fn_span, fn_deps, used_types, &substs,
                 )?;
 
                 // Filter and register the argument types.
@@ -915,15 +862,7 @@ fn register_local_function_body(
                         trace!("terminator: Call: arg: {:?}", a);
 
                         let ty = a.ty(&body.local_decls, tcx);
-                        register_mir_ty(
-                            crate_info,
-                            rdecls,
-                            sess,
-                            tcx,
-                            &fn_span,
-                            &mut fn_decl.deps_tys,
-                            &ty,
-                        )?;
+                        register_mir_ty(crate_info, rdecls, sess, tcx, &fn_span, fn_deps, &ty)?;
                     }
                 }
 
@@ -1015,7 +954,7 @@ fn register_local_function_body(
 /// the def_id to the list of registered ids.
 fn register_local_function(
     crate_info: &CrateInfo,
-    rdecls: &mut RegisteredDeclarations,
+    rdecls: &mut DeclarationsRegister,
     sess: &Session,
     tcx: TyCtxt,
     def_id: LocalDefId,
@@ -1028,29 +967,28 @@ fn register_local_function(
     // Check the generics - TODO: we check this here and in translate_functions_to_im
     generics::check_function_generics(tcx, def_id);
 
-    // Initialize the function declaration that we will register in the
-    // declarations map, and in particular its list of dependencies that
-    // we will progressively fill during exploration.
-    let mut fn_decl = RegisteredFunDeclaration::new(def_id);
-
     // We explore the function definition only if it is not in a module flagged
     // as opaque
     let name = function_def_id_to_name(tcx, def_id);
-    if name.is_in_modules(&crate_info.crate_name, &crate_info.opaque) {
+    if name.is_in_modules(&crate_info.crate_name, &crate_info.opaque_mods) {
         // The function is opaque
         // Store the function declaration in the declaration map
-        rdecls.funs.insert(def_id, fn_decl);
-        rdecls.opaque_funs.insert(def_id);
+        rdecls.add(Declaration::new_opaque(def_id, DeclKind::Function));
         return Ok(());
     }
 
+    let mut fn_deps = DeclDependencies::new();
+
     // The function is not opaque
     // Explore the body
-    register_local_function_body(crate_info, rdecls, sess, tcx, ldef_id, &mut fn_decl)?;
+    register_local_function_body(crate_info, rdecls, sess, tcx, ldef_id, &mut fn_deps)?;
 
     // Store the function declaration in the declarations map
-    rdecls.funs.insert(def_id, fn_decl);
-
+    rdecls.add(Declaration::new_visible(
+        def_id,
+        DeclKind::Function,
+        fn_deps,
+    ));
     return Ok(());
 }
 
@@ -1058,18 +996,18 @@ fn register_local_function(
 /// TODO: Should be refactored with [register_local_function_body].
 fn register_local_constant_body(
     crate_info: &CrateInfo,
-    rdecls: &mut RegisteredDeclarations,
+    rdecls: &mut DeclarationsRegister,
     sess: &Session,
     tcx: TyCtxt,
     def_id: LocalDefId,
-    const_decl: &mut RegisteredConstDeclaration,
+    const_deps: &mut LinkedHashSet<DefId>,
 ) -> Result<()> {
     // Retrieve the MIR code
     let body = crate::get_mir::get_mir_for_def_id(tcx, def_id);
 
     for b in body.basic_blocks().iter() {
         visit_constant_dependencies(b, |c_id| {
-            if const_decl.deps_consts.insert_if_absent(c_id) {
+            if const_deps.insert_if_absent(c_id) {
                 let name = constant_def_id_to_name(tcx, c_id);
                 trace!("added const {:?} dependency: {}", def_id, name);
             }
@@ -1086,7 +1024,7 @@ fn register_local_constant_body(
             sess,
             tcx,
             &v.source_info.span,
-            &mut const_decl.deps_tys,
+            const_deps,
             &v.ty,
         )?;
     }
@@ -1215,19 +1153,12 @@ fn register_local_constant_body(
                 // Add this function to the list of dependencies, only if
                 // it is non-primitive
                 if !is_prim {
-                    const_decl.deps_funs.insert(fid);
+                    const_deps.insert(fid);
                 }
 
                 // Register the types given as parameters.
                 register_mir_substs(
-                    crate_info,
-                    rdecls,
-                    sess,
-                    tcx,
-                    &fn_span,
-                    &mut const_decl.deps_tys,
-                    used_types,
-                    &substs,
+                    crate_info, rdecls, sess, tcx, &fn_span, const_deps, used_types, &substs,
                 )?;
 
                 // Filter and register the argument types.
@@ -1261,15 +1192,7 @@ fn register_local_constant_body(
                         trace!("terminator: Call: arg: {:?}", a);
 
                         let ty = a.ty(&body.local_decls, tcx);
-                        register_mir_ty(
-                            crate_info,
-                            rdecls,
-                            sess,
-                            tcx,
-                            &fn_span,
-                            &mut const_decl.deps_tys,
-                            &ty,
-                        )?;
+                        register_mir_ty(crate_info, rdecls, sess, tcx, &fn_span, const_deps, &ty)?;
                     }
                 }
 
@@ -1361,7 +1284,7 @@ fn register_local_constant_body(
 /// the def_id to the list of registered ids.
 fn register_hir_const(
     crate_info: &CrateInfo,
-    rdecls: &mut RegisteredDeclarations,
+    rdecls: &mut DeclarationsRegister,
     sess: &Session,
     tcx: TyCtxt,
     def_id: LocalDefId,
@@ -1375,29 +1298,28 @@ fn register_hir_const(
     // TODO: Refuse anything depending on a generic parameter.
     generics::check_constant_generics(tcx, def_id);
 
-    // Initialize the constant declaration that we will register in the
-    // declarations map, and in particular its list of dependencies that
-    // we will progressively fill during exploration.
-    let mut const_decl = RegisteredConstDeclaration::new(def_id);
-
     // We explore the constant definition only if it is not in a module flagged
     // as opaque
     let name = constant_def_id_to_name(tcx, def_id);
-    if name.is_in_modules(&crate_info.crate_name, &crate_info.opaque) {
+    if name.is_in_modules(&crate_info.crate_name, &crate_info.opaque_mods) {
         // The constant is opaque
         // Store the constant declaration in the declaration map
-        rdecls.consts.insert(def_id, const_decl);
-        rdecls.opaque_consts.insert(def_id);
+        rdecls.add(Declaration::new_opaque(def_id, DeclKind::Const));
         return Ok(());
     }
 
+    let mut const_deps = DeclDependencies::new();
+
     // The constant is not opaque
     // Explore the body
-    register_local_constant_body(crate_info, rdecls, sess, tcx, ldef_id, &mut const_decl)?;
+    register_local_constant_body(crate_info, rdecls, sess, tcx, ldef_id, &mut const_deps)?;
 
     // Store the constant declaration in the declarations map
-    rdecls.consts.insert(def_id, const_decl);
-
+    rdecls.add(Declaration::new_visible(
+        def_id,
+        DeclKind::Const,
+        const_deps,
+    ));
     return Ok(());
 }
 
@@ -1408,7 +1330,7 @@ fn register_hir_const(
 /// its def_id to the list of registered items otherwise.
 fn register_hir_item(
     crate_info: &CrateInfo,
-    rdecls: &mut RegisteredDeclarations,
+    rdecls: &mut DeclarationsRegister,
     sess: &Session,
     tcx: TyCtxt,
     top_item: bool,
@@ -1421,7 +1343,7 @@ fn register_hir_item(
     // prevent cycles. If not registered yet, do not immediately add it:
     // it may be an item we won't translate (`use module`, `extern crate`...).
     let def_id = item.def_id.to_def_id();
-    if rdecls.decls.contains(&def_id) {
+    if rdecls.knows(&def_id) {
         return Ok(());
     }
 
@@ -1439,7 +1361,7 @@ fn register_hir_item(
                 return Ok(());
             }
             Option::Some(item_name) => {
-                if item_name.is_in_modules(&crate_info.crate_name, &crate_info.opaque) {
+                if item_name.is_in_modules(&crate_info.crate_name, &crate_info.opaque_mods) {
                     return Ok(());
                 }
             }
@@ -1454,17 +1376,17 @@ fn register_hir_item(
             return Ok(());
         }
         ItemKind::Enum(_, _) | ItemKind::Struct(_, _) => {
-            rdecls.decls.insert(def_id);
+            rdecls.add_id(def_id);
             register_hir_type(crate_info, rdecls, sess, tcx, item, def_id)
         }
         ItemKind::OpaqueTy(_) => unimplemented!(),
         ItemKind::Union(_, _) => unimplemented!(),
         ItemKind::Fn(_, _, _) => {
-            rdecls.decls.insert(def_id);
+            rdecls.add_id(def_id);
             return register_local_function(crate_info, rdecls, sess, tcx, item.def_id);
         }
         ItemKind::Const(_, _) => {
-            rdecls.decls.insert(def_id);
+            rdecls.add_id(def_id);
             return register_hir_const(crate_info, rdecls, sess, tcx, item.def_id);
         }
         ItemKind::Impl(impl_block) => {
@@ -1502,7 +1424,7 @@ fn register_hir_item(
             // exist
             trace!("{:?}", def_id);
             let module_name = module_def_id_to_name(tcx, def_id);
-            let opaque = module_name.is_in_modules(&crate_info.crate_name, &crate_info.opaque);
+            let opaque = module_name.is_in_modules(&crate_info.crate_name, &crate_info.opaque_mods);
             if opaque {
                 // Ignore
                 trace!("Ignoring module [{}] because marked as opaque", module_name);
@@ -1530,14 +1452,14 @@ fn register_hir_item(
 /// its def_id to the list of registered items otherwise.
 fn register_hir_impl_item(
     crate_info: &CrateInfo,
-    rdecls: &mut RegisteredDeclarations,
+    rdecls: &mut DeclarationsRegister,
     sess: &Session,
     tcx: TyCtxt,
     impl_item: &ImplItem,
 ) -> Result<()> {
     // Check if the item has already been registered
     let def_id = impl_item.def_id.to_def_id();
-    if rdecls.decls.contains(&def_id) {
+    if rdecls.knows(&def_id) {
         return Ok(());
     }
 
@@ -1551,7 +1473,7 @@ fn register_hir_impl_item(
         ImplItemKind::Fn(_, _) => {
             let local_def_id = impl_item.def_id;
             let def_id = local_def_id.to_def_id();
-            rdecls.decls.insert(def_id);
+            rdecls.add_id(def_id);
             register_local_function(crate_info, rdecls, sess, tcx, local_def_id)
         }
     }
@@ -1563,7 +1485,7 @@ pub fn register_crate(
     sess: &Session,
     tcx: TyCtxt,
 ) -> Result<RegisteredDeclarations> {
-    let mut registered_decls = RegisteredDeclarations::new();
+    let mut decls = DeclarationsRegister::new();
 
     // TODO: in order to have a good ordering when extracting the information
     // from a crate with several modules, it would be better to not register
@@ -1577,7 +1499,7 @@ pub fn register_crate(
     //   of the form "mod MODULE_NAME")
     // - the other files in the crate are Module items in the HIR graph
     for item in tcx.hir().items() {
-        register_hir_item(crate_info, &mut registered_decls, sess, tcx, true, item)?;
+        register_hir_item(crate_info, &mut decls, sess, tcx, true, item)?;
     }
-    return Ok(registered_decls);
+    return Ok(decls.get_declarations());
 }

--- a/charon/src/register.rs
+++ b/charon/src/register.rs
@@ -66,7 +66,7 @@ impl Declaration {
         }
     }
 
-    fn new_visible(id: DefId, kind: DeclKind, deps: LinkedHashSet<DefId>) -> Declaration {
+    fn new_visible(id: DefId, kind: DeclKind, deps: DeclDependencies) -> Declaration {
         Declaration {
             id,
             kind,
@@ -350,7 +350,7 @@ fn register_mir_substs<'tcx>(
     ctx: &RegisterContext,
     decls: &mut DeclarationsRegister,
     span: &Span,
-    ty_deps: &mut LinkedHashSet<DefId>,
+    ty_deps: &mut DeclDependencies,
     used_params: Option<Vec<bool>>,
     substs: &rustc_middle::ty::subst::SubstsRef<'tcx>,
 ) -> Result<()> {
@@ -396,7 +396,7 @@ fn register_mir_ty(
     ctx: &RegisterContext,
     decls: &mut DeclarationsRegister,
     span: &Span,
-    ty_deps: &mut LinkedHashSet<DefId>,
+    ty_deps: &mut DeclDependencies,
     ty: &Ty,
 ) -> Result<()> {
     trace!("> ty: {:?}", ty);
@@ -694,7 +694,7 @@ fn register_body(
     ctx: &RegisterContext,
     decls: &mut DeclarationsRegister,
     def_id: LocalDefId,
-    deps: &mut LinkedHashSet<DefId>,
+    deps: &mut DeclDependencies,
 ) -> Result<()> {
     // Retrieve the MIR code
     let body = crate::get_mir::get_mir_for_def_id(ctx.rustc, def_id);

--- a/charon/src/register.rs
+++ b/charon/src/register.rs
@@ -37,6 +37,7 @@ impl CrateInfo {
 }
 
 /// All kind of supported Rust top-level declarations.
+/// const & static variables are merged together in the global kind.
 #[derive(Debug, PartialEq, Eq)]
 pub enum DeclKind {
     Type,
@@ -47,6 +48,12 @@ pub enum DeclKind {
 pub type DeclDependencies = LinkedHashSet<DefId>;
 
 /// A registered declaration, listing its dependencies.
+///
+/// TODO: Add a flag to indicate that the expression can be evaluated
+///       at compile time (const VS static, const fn VS fn).
+///       They should be accepted even if they don't have body :
+///       it's only when they used in compile time context that it will fail.
+///       It can happen for e.g. a private const value or function.
 #[derive(Debug)]
 pub struct Declaration {
     // The declaration may be local or extern (id.is_local()).

--- a/charon/src/remove_unused_locals.rs
+++ b/charon/src/remove_unused_locals.rs
@@ -16,7 +16,7 @@ fn compute_used_locals_in_place(locals: &mut HashSet<VarId::Id>, p: &Place) {
 fn compute_used_locals_in_operand(locals: &mut HashSet<VarId::Id>, op: &Operand) {
     match op {
         Operand::Copy(p) | Operand::Move(p) => compute_used_locals_in_place(locals, p),
-        Operand::Constant(_, _) => (),
+        Operand::Const(_, _) => (),
     }
 }
 
@@ -95,7 +95,7 @@ fn transform_operand(vids_map: &HashMap<VarId::Id, VarId::Id>, op: Operand) -> O
     match op {
         Operand::Copy(p) => Operand::Copy(transform_place(vids_map, p)),
         Operand::Move(p) => Operand::Move(transform_place(vids_map, p)),
-        Operand::Constant(ty, cv) => Operand::Constant(ty, cv),
+        Operand::Const(ty, cv) => Operand::Const(ty, cv),
     }
 }
 

--- a/charon/src/reorder_decls.rs
+++ b/charon/src/reorder_decls.rs
@@ -1,5 +1,6 @@
 use crate::common::*;
 use crate::graphs::*;
+use crate::register::DeclKind;
 use crate::register::RegisteredDeclarations;
 use macros::{VariantIndexArity, VariantName};
 use petgraph::algo::tarjan_scc;
@@ -216,26 +217,6 @@ impl<'a, TypeId: Copy, FunId: Copy, ConstId: Copy> std::iter::IntoIterator
     }
 }
 
-#[derive(PartialEq, Eq)]
-enum DefIdKind {
-    Type,
-    Fun,
-    Const,
-}
-
-// Less efficient than a lookup on the needed type, but performs a sanity check.
-fn get_def_id_kind(decls: &RegisteredDeclarations, def_id: &DefId) -> DefIdKind {
-    if decls.types.contains_key(def_id) {
-        DefIdKind::Type
-    } else if decls.funs.contains_key(def_id) {
-        DefIdKind::Fun
-    } else if decls.consts.contains_key(def_id) {
-        DefIdKind::Const
-    } else {
-        panic!("unknown id {:?}", def_id);
-    }
-}
-
 pub fn reorder_declarations(
     decls: &RegisteredDeclarations,
 ) -> Result<DeclarationsGroups<DefId, DefId, DefId>> {
@@ -245,49 +226,16 @@ pub fn reorder_declarations(
     let mut graph = DiGraphMap::<DefId, ()>::new();
 
     // Add the nodes - note that we are using both local and external def ids.
-    for d in decls.decls.iter() {
-        graph.add_node(*d);
+    for (id, _) in decls.iter() {
+        graph.add_node(*id);
     }
 
-    // Add the edges.
-    // Note that some of the dependencies might be foreign dependencies (i.e.:
-    // not defined in the local crate).
-    // Types -> types
-    decls.types.iter().for_each(|(id, d)| {
-        d.deps.iter().for_each(|dep_id| {
-            let _ = graph.add_edge(*id, *dep_id, ());
-        })
-    });
-    // Functions
-    decls.funs.iter().for_each(|(id, d)| {
-        // Functions -> types
-        d.deps_tys.iter().for_each(|dep_id| {
-            let _ = graph.add_edge(*id, *dep_id, ());
-        });
-        // Functions -> functions
-        d.deps_funs.iter().for_each(|dep_id| {
-            let _ = graph.add_edge(*id, *dep_id, ());
-        });
-        // Functions -> constants
-        d.deps_consts.iter().for_each(|dep_id| {
-            let _ = graph.add_edge(*id, *dep_id, ());
-        });
-    });
-    // Constants
-    decls.funs.iter().for_each(|(id, d)| {
-        // Constants -> types
-        d.deps_tys.iter().for_each(|dep_id| {
-            let _ = graph.add_edge(*id, *dep_id, ());
-        });
-        // Constants -> functions
-        d.deps_funs.iter().for_each(|dep_id| {
-            let _ = graph.add_edge(*id, *dep_id, ());
-        });
-        // Constants -> constants
-        d.deps_consts.iter().for_each(|dep_id| {
-            let _ = graph.add_edge(*id, *dep_id, ());
-        });
-    });
+    // Add the edges, which go from a declaration to its dependency.
+    for (src, d) in decls.iter() {
+        for tgt in d.deps.iter().flatten() {
+            graph.add_edge(*src, *tgt, ());
+        }
+    }
 
     trace!("Graph: {:?}", graph);
 
@@ -298,49 +246,17 @@ pub fn reorder_declarations(
     // given by the user. To be more precise, if we don't need to move
     // definitions, the order in which we generate the declarations should
     // be the same as the one in which the user wrote them.
-    let get_id_dependencies: &dyn Fn(DefId) -> Vec<DefId> = &|id| {
-        match get_def_id_kind(decls, &id) {
-            DefIdKind::Type => {
-                // Retrieve the type dependencies, and filter the foreign ids
-                decls
-                    .types
-                    .get(&id)
-                    .unwrap()
-                    .deps
-                    .iter()
-                    .map(|id| *id)
-                    .collect()
-            }
-            DefIdKind::Fun => {
-                let decl = &decls.funs.get(&id).unwrap();
-                // We need to chain the type and the function dependencies, and
-                // filter the foreign ids
-                decl.deps_tys
-                    .iter()
-                    .chain(decl.deps_funs.iter())
-                    .chain(decl.deps_consts.iter())
-                    .map(|id| *id)
-                    .collect()
-            }
-            DefIdKind::Const => {
-                let decl = &decls.consts.get(&id).unwrap();
-                // We need to chain the type and the constant dependencies, and
-                // filter the foreign ids
-                decl.deps_tys
-                    .iter()
-                    .chain(decl.deps_funs.iter())
-                    .chain(decl.deps_consts.iter())
-                    .map(|id| *id)
-                    .collect()
-            }
-        }
+    let get_id_dependencies = &|id| {
+        // TODO: There was a comment about "filter the foreign ids" (ignored by the code).
+        //       Find that it's about.
+        decls[&id].deps.iter().flatten().map(|d| *d).collect()
     };
     let SCCs {
         sccs: reordered_sccs,
         scc_deps: _,
     } = reorder_sccs::<DefId>(
         get_id_dependencies,
-        &decls.decls.iter().map(|id| *id).collect(),
+        &decls.iter().map(|(id, _)| *id).collect(),
         &sccs,
     );
 
@@ -352,69 +268,51 @@ pub fn reorder_declarations(
         // Retrieve the SCC
         assert!(scc.len() > 0);
 
-        // Sanity check: make sure an SCC is made of type declarations only,
-        // or of function declarations only.
         // Note that the length of an SCC should be at least 1.
         let mut it = scc.iter();
-        let id0 = it.next().unwrap();
-        let def_kind = get_def_id_kind(decls, &id0);
-
-        for id in it {
-            match def_kind {
-                DefIdKind::Type => assert!(decls.types.contains_key(id)),
-                DefIdKind::Fun => assert!(decls.funs.contains_key(id)),
-                DefIdKind::Const => assert!(decls.consts.contains_key(id)),
-            }
-        }
+        let id0 = *it.next().unwrap();
+        let decl = &decls[&id0];
 
         // If an SCC has length one, the declaration may be simply recursive:
         // we determine whether it is the case by checking if the def id is in
         // its own set of dependencies.
-        let is_simply_recursive;
-        if scc.len() == 1 {
-            let deps = match def_kind {
-                DefIdKind::Type => &decls.types.get(&id0).unwrap().deps,
-                DefIdKind::Fun => &decls.funs.get(&id0).unwrap().deps_funs,
-                DefIdKind::Const => &decls.consts.get(&id0).unwrap().deps_consts,
-            };
-            is_simply_recursive = deps.contains(&id0);
-        } else {
-            is_simply_recursive = false;
-        }
+        let is_mutually_recursive = scc.len() > 1;
+        let is_simply_recursive =
+            !is_mutually_recursive && decl.deps.as_ref().is_some_with(|deps| deps.contains(&id0));
 
         // Add the declaration.
         // Note that we clone the vectors: it is not optimal, but they should
         // be pretty small.
-        let wrap_group = |x| match def_kind {
-            DefIdKind::Type => DeclarationGroup::Type(x),
-            DefIdKind::Fun => DeclarationGroup::Fun(x),
-            DefIdKind::Const => DeclarationGroup::Const(x),
-        };
-        if scc.len() == 1 && !is_simply_recursive {
-            reordered_decls.push(wrap_group(GDeclarationGroup::NonRec(*id0)));
+        let group = if is_mutually_recursive || is_simply_recursive {
+            GDeclarationGroup::Rec(scc.clone())
         } else {
-            reordered_decls.push(wrap_group(GDeclarationGroup::Rec(scc.clone())));
-        }
+            GDeclarationGroup::NonRec(id0)
+        };
+        reordered_decls.push(match decl.kind {
+            DeclKind::Type => DeclarationGroup::Type(group),
+            DeclKind::Function => DeclarationGroup::Fun(group),
+            DeclKind::Const | DeclKind::Static => DeclarationGroup::Const(group),
+        });
     }
 
     trace!("{}", reordered_decls.to_string());
 
     // We list the external definitions (opaque local, and non-local)
-    for id in decls.decls.iter() {
-        match get_def_id_kind(decls, id) {
-            DefIdKind::Type => {
-                if !id.is_local() || decls.opaque_types.contains(id) {
-                    reordered_decls.external_type_ids.insert(*id);
+    for (_, decl) in decls.iter() {
+        match decl.kind {
+            DeclKind::Type => {
+                if !decl.is_local() || !decl.is_visible() {
+                    reordered_decls.external_type_ids.insert(decl.id);
                 }
             }
-            DefIdKind::Fun => {
-                if !id.is_local() || decls.opaque_funs.contains(id) {
-                    reordered_decls.external_fun_ids.insert(*id);
+            DeclKind::Function => {
+                if !decl.is_local() || !decl.is_visible() {
+                    reordered_decls.external_fun_ids.insert(decl.id);
                 }
             }
-            DefIdKind::Const => {
-                if !id.is_local() || decls.opaque_consts.contains(id) {
-                    reordered_decls.external_const_ids.insert(*id);
+            DeclKind::Const | DeclKind::Static => {
+                if !decl.is_local() || !decl.is_visible() {
+                    reordered_decls.external_const_ids.insert(decl.id);
                 }
             }
         }

--- a/charon/src/rust_to_local_ids.rs
+++ b/charon/src/rust_to_local_ids.rs
@@ -20,7 +20,7 @@ pub struct OrderedDecls {
     /// The opaque fun ids
     pub opaque_funs: HashSet<ast::FunDeclId::Id>,
     /// The opaque const ids
-    pub opaque_consts: HashSet<ast::GlobalDeclId::Id>,
+    pub opaque_globals: HashSet<ast::GlobalDeclId::Id>,
     /// Rust type identifiers to translation identifiers
     pub type_rid_to_id: HashMap<DefId, ty::TypeDeclId::Id>,
     /// Translation type identifiers to rust identifiers
@@ -137,7 +137,7 @@ pub fn rust_to_local_ids(reordered: &rd::DeclarationsGroups<DefId, DefId, DefId>
         decls,
         opaque_types,
         opaque_funs,
-        opaque_consts,
+        opaque_globals: opaque_consts,
         type_rid_to_id,
         fun_rid_to_id,
         const_rid_to_id,

--- a/charon/src/simplify_ops.rs
+++ b/charon/src/simplify_ops.rs
@@ -150,7 +150,7 @@ fn check_if_simplifiable_assert_then_unop(
                 Rvalue::BinaryOp(
                     BinOp::Eq,
                     op,
-                    Operand::Constant(
+                    Operand::Const(
                         _,
                         OperandConstantValue::ConstantValue(ConstantValue::Scalar(saturated)),
                     ),
@@ -173,7 +173,7 @@ fn check_if_simplifiable_assert_then_unop(
             // - or they are the same constant
             match (op, op1) {
                 (Operand::Copy(p), Operand::Move(p1)) => assert!(p == p1),
-                (Operand::Constant(_, cv), Operand::Constant(_, cv1)) => assert!(cv == cv1),
+                (Operand::Const(_, cv), Operand::Const(_, cv1)) => assert!(cv == cv1),
                 _ => unreachable!(),
             }
 
@@ -187,7 +187,7 @@ fn check_if_simplifiable_assert_then_unop(
                 _mp,
                 Rvalue::UnaryOp(
                     unop,
-                    Operand::Constant(
+                    Operand::Const(
                         _,
                         OperandConstantValue::ConstantValue(ConstantValue::Scalar(value)),
                     ),
@@ -382,7 +382,7 @@ fn check_if_simplifiable_assert_then_binop(
                 Rvalue::BinaryOp(
                     BinOp::Eq,
                     Operand::Copy(eq_op1),
-                    Operand::Constant(
+                    Operand::Const(
                         _,
                         OperandConstantValue::ConstantValue(ConstantValue::Scalar(zero)),
                     ),
@@ -412,7 +412,7 @@ fn check_if_simplifiable_assert_then_binop(
                 Rvalue::BinaryOp(
                     BinOp::Eq,
                     divisor,
-                    Operand::Constant(
+                    Operand::Const(
                         _,
                         OperandConstantValue::ConstantValue(ConstantValue::Scalar(zero)),
                     ),
@@ -427,9 +427,9 @@ fn check_if_simplifiable_assert_then_binop(
             // Case 2: pattern with constant divisor and assertion
             assert!(binop_requires_assert_before(*binop));
             assert!(!(*expected));
-            assert!(divisor.is_constant());
+            assert!(divisor.is_const());
             match divisor {
-                Operand::Constant(
+                Operand::Const(
                     _,
                     OperandConstantValue::ConstantValue(ConstantValue::Scalar(_)),
                 ) => (),
@@ -445,7 +445,7 @@ fn check_if_simplifiable_assert_then_binop(
             }
             true
         }
-        (_, _, Statement::Assign(_mp, Rvalue::BinaryOp(_, _, Operand::Constant(_, divisor)))) => {
+        (_, _, Statement::Assign(_mp, Rvalue::BinaryOp(_, _, Operand::Const(_, divisor)))) => {
             // Case 3: no assertion to check the divisor != 0, the divisor must be a
             // non-zero constant
             let cv = divisor.as_constant_value();
@@ -531,7 +531,7 @@ fn simplify_st(st: Statement) -> Statement {
                     if binop_can_fail(*binop) {
                         match binop {
                             BinOp::Div | BinOp::Rem => {
-                                let (_, cv) = divisor.as_constant();
+                                let (_, cv) = divisor.as_const();
                                 let cv = cv.as_constant_value();
                                 let cv = cv.as_scalar();
                                 if cv.is_uint() {
@@ -553,7 +553,7 @@ fn simplify_st(st: Statement) -> Statement {
                     if unop_can_fail(*unop) {
                         match unop {
                             UnOp::Neg => {
-                                let (_, cv) = v.as_constant();
+                                let (_, cv) = v.as_const();
                                 let cv = cv.as_constant_value();
                                 let cv = cv.as_scalar();
                                 assert!(cv.is_int());

--- a/charon/src/translate_functions_to_im.rs
+++ b/charon/src/translate_functions_to_im.rs
@@ -11,7 +11,7 @@ use crate::formatter::Formatter;
 use crate::generics;
 use crate::get_mir::EXTRACT_CONSTANTS_AT_TOP_LEVEL;
 use crate::im_ast as ast;
-use crate::names::constant_def_id_to_name;
+use crate::names::global_def_id_to_name;
 use crate::names::{function_def_id_to_name, type_def_id_to_name};
 use crate::regions_hierarchy as rh;
 use crate::regions_hierarchy::TypesConstraintsMap;
@@ -2283,7 +2283,7 @@ fn translate_constant(
     };
 
     // Translate the constant name
-    let name = constant_def_id_to_name(tcx, rid);
+    let name = global_def_id_to_name(tcx, rid);
 
     trace!("Translating constant type");
     let mir_ty = tcx.type_of(rid);

--- a/charon/src/translate_types.rs
+++ b/charon/src/translate_types.rs
@@ -750,7 +750,7 @@ pub fn translate_types(
                     );
                 }
             },
-            DeclarationGroup::Fun(_) | DeclarationGroup::Const(_) => {
+            DeclarationGroup::Fun(_) | DeclarationGroup::Global(_) => {
                 // Ignore the functions & constants
             }
         }

--- a/charon/src/types_utils.rs
+++ b/charon/src/types_utils.rs
@@ -4,7 +4,7 @@
 use crate::common::*;
 use crate::formatter::Formatter;
 use crate::id_vector;
-use crate::im_ast::ConstDeclId;
+use crate::im_ast::GlobalDeclId;
 use crate::types::*;
 use im::{HashMap, OrdSet, Vector};
 use rustc_middle::ty::{IntTy, UintTy};
@@ -367,7 +367,7 @@ impl IntegerTy {
 pub fn type_def_id_to_pretty_string(id: TypeDeclId::Id) -> String {
     format!("@Adt{}", id).to_string()
 }
-pub fn const_def_id_to_pretty_string(id: ConstDeclId::Id) -> String {
+pub fn const_def_id_to_pretty_string(id: GlobalDeclId::Id) -> String {
     format!("@Const{}", id).to_string()
 }
 

--- a/charon/src/values_utils.rs
+++ b/charon/src/values_utils.rs
@@ -4,7 +4,7 @@
 
 use crate::common::*;
 use crate::formatter::Formatter;
-use crate::im_ast::ConstDeclId;
+use crate::im_ast::GlobalDeclId;
 use crate::types::*;
 use crate::values::*;
 use serde::ser::SerializeTupleVariant;
@@ -28,8 +28,8 @@ impl Formatter<TypeDeclId::Id> for DummyFormatter {
     }
 }
 
-impl Formatter<ConstDeclId::Id> for DummyFormatter {
-    fn format_object(&self, id: ConstDeclId::Id) -> String {
+impl Formatter<GlobalDeclId::Id> for DummyFormatter {
+    fn format_object(&self, id: GlobalDeclId::Id) -> String {
         const_def_id_to_pretty_string(id)
     }
 }

--- a/tests-nll/src/betree.rs
+++ b/tests-nll/src/betree.rs
@@ -251,12 +251,12 @@ pub fn upsert_update(prev: Option<Value>, st: UpsertFunState) -> Value {
             match st {
                 UpsertFunState::Add(v) => {
                     // Note that Aeneas is a bit conservative about the max_usize
-                    let margin = u64::MAX - prev;
+                    let margin = 18446744073709551615u64 - prev;
                     // Check if we saturate
                     if margin >= v {
                         prev + v
                     } else {
-                        u64::MAX
+                        18446744073709551615u64
                     }
                 }
                 UpsertFunState::Sub(v) => {

--- a/tests-nll/src/betree.rs
+++ b/tests-nll/src/betree.rs
@@ -251,12 +251,12 @@ pub fn upsert_update(prev: Option<Value>, st: UpsertFunState) -> Value {
             match st {
                 UpsertFunState::Add(v) => {
                     // Note that Aeneas is a bit conservative about the max_usize
-                    let margin = 18446744073709551615u64 - prev;
+                    let margin = u64::MAX - prev;
                     // Check if we saturate
                     if margin >= v {
                         prev + v
                     } else {
-                        18446744073709551615u64
+                        u64::MAX
                     }
                 }
                 UpsertFunState::Sub(v) => {

--- a/tests/src/constants.rs
+++ b/tests/src/constants.rs
@@ -44,7 +44,7 @@ const fn unwrap_y() -> i32 {
     Y.val
 }
 
-const Yval: i32 = unwrap_y();
+const YVAL: i32 = unwrap_y();
 
 struct Wrap<T> {
     val: T,
@@ -58,7 +58,7 @@ impl<T> Wrap<T> {
 
 // Additions
 
-const fn get_Z1() -> i32 {
+const fn get_z1() -> i32 {
     const Z1: i32 = 3;
     Z1
 }
@@ -67,8 +67,8 @@ const fn add(a: i32, b: i32) -> i32 {
     a + b
 }
 
-const fn get_Z2() -> i32 {
-    add(Q1, add(get_Z1(), Q3))
+const fn get_z2() -> i32 {
+    add(Q1, add(get_z1(), Q3))
 }
 
 const Q1: i32 = 5;

--- a/tests/src/constants.rs
+++ b/tests/src/constants.rs
@@ -5,7 +5,7 @@
 
 const X0: u32 = 0;
 
-//const X1: u32 = u32::MAX;
+const X1: u32 = u32::MAX;
 
 const X2: u32 = {
     let x = 3;

--- a/tests/src/constants.rs
+++ b/tests/src/constants.rs
@@ -5,14 +5,14 @@
 
 const X0: u32 = 0;
 
-const X1: u32 = u32::MAX;
+//const X1: u32 = u32::MAX;
 
 const X2: u32 = {
     let x = 3;
     x
 };
 
-const X3: u32 = incr(32);
+static X3: u32 = incr(32);
 
 const fn incr(n: u32) -> u32 {
     n + 1

--- a/tests/src/hashmap.rs
+++ b/tests/src/hashmap.rs
@@ -148,7 +148,7 @@ impl<T> HashMap<T> {
         // here, which gets compiled by the MIR interpreter (so we don't see
         // the conversion, actually).
         // Rk.: this is a hit heavy...
-        let max_usize = 4294967295u32 as usize;
+        let max_usize = u32::MAX as usize;
         let capacity = self.slots.len();
         // Checking that there won't be overflows by using the fact that, if m > 0:
         // n * m <= p <==> n <= p / m

--- a/tests/src/hashmap.rs
+++ b/tests/src/hashmap.rs
@@ -148,7 +148,7 @@ impl<T> HashMap<T> {
         // here, which gets compiled by the MIR interpreter (so we don't see
         // the conversion, actually).
         // Rk.: this is a hit heavy...
-        let max_usize = u32::MAX as usize;
+        let max_usize = 4294967295u32 as usize;
         let capacity = self.slots.len();
         // Checking that there won't be overflows by using the fact that, if m > 0:
         // n * m <= p <==> n <= p / m


### PR DESCRIPTION
Improvements on the constants branch :
- Remove code duplication
- Support again external constants
- Extend constant support to "const" and "static" declarations

A declaration which is either "const" or "static" is now called a global.